### PR TITLE
Draft: natively support fmks coordinates 

### DIFF
--- a/input/example.input
+++ b/input/example.input
@@ -140,18 +140,22 @@ adaptive_region_1_y_min = -6.0  # region 1: bottom boundary in gravitational uni
 adaptive_region_1_y_max = 6.0   # region 1: top boundary in gravitational units
 
 # Plasma parameters
-plasma_mu         = 0.5         # molecular weight of fluid in proton masses
-plasma_ne_ni      = 1.0         # electrons per ion
-plasma_model      = ti_te_beta  # thermal electron temperature model (ti_te_beta, code_kappa)
-plasma_rat_low    = 1.0         # ion-electron temperature ratio at zero plasma beta
-plasma_rat_high   = 10.0        # ion-electron temperature ratio at infinite plasma beta
-plasma_power_frac = 0.0         # fraction of electrons with power-law distribution
-plasma_p          = 3.0         # power-law index
-plasma_gamma_min  = 1.0         # minimum Lorentz factor in power law
-plasma_gamma_max  = 10.0        # maximum Lorentz factor in power law
-plasma_kappa_frac = 0.0         # fraction of electrons with kappa distribution
-plasma_kappa      = 3.5         # kappa parameter for kappa distribution
-plasma_w          = 1.0         # w parameter for kappa distribution
+plasma_mu         = 0.5                 # molecular weight of fluid in proton masses
+plasma_ne_ni      = 1.0                 # electrons per ion
+plasma_model      = ti_te_beta          # electron temperature model (ti_te_beta, code_kappa)
+plasma_use_p      = true                # flag indicating total p (rather than u) should match sim.
+plasma_gamma      = 1.4444444444444444  # total adiabatic index
+plasma_gamma_i    = 1.6666666666666667  # ion adiabatic index
+plasma_gamma_e    = 1.3333333333333333  # electron adiabatic index
+plasma_rat_low    = 1.0                 # ion-electron temperature ratio at zero plasma beta
+plasma_rat_high   = 10.0                # ion-electron temperature ratio at infinite plasma beta
+plasma_power_frac = 0.0                 # fraction of electrons with power-law distribution
+plasma_p          = 3.0                 # power-law index
+plasma_gamma_min  = 1.0                 # minimum Lorentz factor in power law
+plasma_gamma_max  = 10.0                # maximum Lorentz factor in power law
+plasma_kappa_frac = 0.0                 # fraction of electrons with kappa distribution
+plasma_kappa      = 3.5                 # kappa parameter for kappa distribution
+plasma_w          = 1.0                 # w parameter for kappa distribution
 
 # Cut parameters
 cut_rho_min          = -1.0         # if nonneg., cutoff in rho below which plasma is ignored

--- a/input/example_adaptive.input
+++ b/input/example_adaptive.input
@@ -98,6 +98,7 @@ adaptive_region_1_y_max = 6.0   # region 1: top boundary in gravitational units
 plasma_mu         = 0.5         # molecular weight of fluid in proton masses
 plasma_ne_ni      = 1.0         # electrons per ion
 plasma_model      = ti_te_beta  # thermal electron temperature model (ti_te_beta, code_kappa)
+plasma_use_p      = true        # flag indicating total p (rather than u) should match simulation
 plasma_rat_low    = 1.0         # ion-electron temperature ratio at zero plasma beta
 plasma_rat_high   = 10.0        # ion-electron temperature ratio at infinite plasma beta
 plasma_power_frac = 0.0         # fraction of electrons with power-law distribution

--- a/input/example_render.input
+++ b/input/example_render.input
@@ -97,6 +97,7 @@ adaptive_max_level = 0  # maximum number of adaptive levels beyond root
 plasma_mu         = 0.5         # molecular weight of fluid in proton masses
 plasma_ne_ni      = 1.0         # electrons per ion
 plasma_model      = ti_te_beta  # thermal electron temperature model (ti_te_beta, code_kappa)
+plasma_use_p      = true        # flag indicating total p (rather than u) should match simulation
 plasma_rat_low    = 1.0         # ion-electron temperature ratio at zero plasma beta
 plasma_rat_high   = 10.0        # ion-electron temperature ratio at infinite plasma beta
 plasma_power_frac = 0.0         # fraction of electrons with power-law distribution

--- a/input/example_simulation.input
+++ b/input/example_simulation.input
@@ -80,6 +80,7 @@ adaptive_max_level = 0  # maximum number of adaptive levels beyond root
 plasma_mu         = 0.5         # molecular weight of fluid in proton masses
 plasma_ne_ni      = 1.0         # electrons per ion
 plasma_model      = ti_te_beta  # thermal electron temperature model (ti_te_beta, code_kappa)
+plasma_use_p      = true        # flag indicating total p (rather than u) should match simulation
 plasma_rat_low    = 1.0         # ion-electron temperature ratio at zero plasma beta
 plasma_rat_high   = 10.0        # ion-electron temperature ratio at infinite plasma beta
 plasma_power_frac = 0.0         # fraction of electrons with power-law distribution

--- a/input/example_true_color.input
+++ b/input/example_true_color.input
@@ -81,6 +81,7 @@ adaptive_max_level = 0  # maximum number of adaptive levels beyond root
 plasma_mu         = 0.5         # molecular weight of fluid in proton masses
 plasma_ne_ni      = 1.0         # electrons per ion
 plasma_model      = ti_te_beta  # thermal electron temperature model (ti_te_beta, code_kappa)
+plasma_use_p      = true        # flag indicating total p (rather than u) should match simulation
 plasma_rat_low    = 1.0         # ion-electron temperature ratio at zero plasma beta
 plasma_rat_high   = 10.0        # ion-electron temperature ratio at infinite plasma beta
 plasma_power_frac = 0.0         # fraction of electrons with power-law distribution

--- a/src/blacklight.hpp
+++ b/src/blacklight.hpp
@@ -36,7 +36,7 @@ namespace CellValues
 enum struct ModelType {simulation, formula};
 enum struct OutputFormat {npz, npy, raw};
 enum struct SimulationFormat {athena, athenak, iharm3d, harm3d};
-enum struct Coordinates {sks, cks, fmks};
+enum struct Coordinates {cks, sks, fmks};
 enum struct Camera {plane, pinhole};
 enum struct RayTerminate {photon, multiplicative, additive};
 enum struct RayIntegrator {dp, rk4, rk2};

--- a/src/blacklight.hpp
+++ b/src/blacklight.hpp
@@ -36,7 +36,7 @@ namespace CellValues
 enum struct ModelType {simulation, formula};
 enum struct OutputFormat {npz, npy, raw};
 enum struct SimulationFormat {athena, athenak, iharm3d, harm3d};
-enum struct Coordinates {sks, cks};
+enum struct Coordinates {sks, cks, fmks};
 enum struct Camera {plane, pinhole};
 enum struct RayTerminate {photon, multiplicative, additive};
 enum struct RayIntegrator {dp, rk4, rk2};

--- a/src/input_reader/enum_readers.cpp
+++ b/src/input_reader/enum_readers.cpp
@@ -89,18 +89,18 @@ SimulationFormat InputReader::ReadSimulationFormat(const std::string &string)
 //   returned value: valid Coordinates
 // Notes:
 //   Valid options:
-//     "sks": spherical Kerr-Schild
 //     "cks": Cartesian Kerr-Schild
+//     "sks": spherical Kerr-Schild
 //     "mks": modified spherical Kerr-Schild (2003 ApJ 589 444)
-//     "fmks": funky modified spherical Kerr-Schild (2022 ApJS 259 64W)
+//     "fmks": funky modified spherical Kerr-Schild (2022 ApJS 259 64)
 Coordinates InputReader::ReadCoordinates(const std::string &string)
 {
-  if (string == "sks" or string == "mks")
+  if (string == "cks")
+    return Coordinates::cks;
+  else if (string == "sks" or string == "mks")
     return Coordinates::sks;
   else if (string == "fmks")
     return Coordinates::fmks;
-  else if (string == "cks")
-    return Coordinates::cks;
   else
     throw BlacklightException("Unknown string used for Coordinates value.");
 }

--- a/src/input_reader/enum_readers.cpp
+++ b/src/input_reader/enum_readers.cpp
@@ -92,10 +92,13 @@ SimulationFormat InputReader::ReadSimulationFormat(const std::string &string)
 //     "sks": spherical Kerr-Schild
 //     "cks": Cartesian Kerr-Schild
 //     "mks": modified spherical Kerr-Schild (2003 ApJ 589 444)
+//     "fmks": funky modified spherical Kerr-Schild (2022 ApJS 259 64W)
 Coordinates InputReader::ReadCoordinates(const std::string &string)
 {
   if (string == "sks" or string == "mks")
     return Coordinates::sks;
+  else if (string == "fmks")
+    return Coordinates::fmks;
   else if (string == "cks")
     return Coordinates::cks;
   else

--- a/src/input_reader/input_reader.cpp
+++ b/src/input_reader/input_reader.cpp
@@ -321,6 +321,14 @@ int InputReader::Read()
       plasma_ne_ni = std::stod(val);
     else if (key == "plasma_model")
       plasma_model = ReadPlasmaModel(val);
+    else if (key == "plasma_use_p")
+      plasma_use_p = ReadBool(val);
+    else if (key == "plasma_gamma")
+      plasma_gamma = std::stod(val);
+    else if (key == "plasma_gamma_i")
+      plasma_gamma_i = std::stod(val);
+    else if (key == "plasma_gamma_e")
+      plasma_gamma_e = std::stod(val);
     else if (key == "plasma_rat_low")
       plasma_rat_low = std::stod(val);
     else if (key == "plasma_rat_high")
@@ -339,12 +347,6 @@ int InputReader::Read()
       plasma_kappa = std::stod(val);
     else if (key == "plasma_w")
       plasma_w = std::stod(val);
-    else if (key == "adiabatic_gamma_elec")
-      adiabatic_gamma_elec = std::stod(val);
-    else if (key == "adiabatic_gamma_ion")
-      adiabatic_gamma_ion = std::stod(val);
-    else if (key == "use_ipole_tpte")
-      use_ipole_tpte = ReadBool(val);
 
     // Store cut parameters
     else if (key == "cut_rho_min")

--- a/src/input_reader/input_reader.cpp
+++ b/src/input_reader/input_reader.cpp
@@ -343,6 +343,8 @@ int InputReader::Read()
       adiabatic_gamma_elec = std::stod(val);
     else if (key == "adiabatic_gamma_ion")
       adiabatic_gamma_ion = std::stod(val);
+    else if (key == "use_ipole_tpte")
+      use_ipole_tpte = ReadBool(val);
 
     // Store cut parameters
     else if (key == "cut_rho_min")

--- a/src/input_reader/input_reader.cpp
+++ b/src/input_reader/input_reader.cpp
@@ -339,6 +339,10 @@ int InputReader::Read()
       plasma_kappa = std::stod(val);
     else if (key == "plasma_w")
       plasma_w = std::stod(val);
+    else if (key == "adiabatic_gamma_elec")
+      adiabatic_gamma_elec = std::stod(val);
+    else if (key == "adiabatic_gamma_ion")
+      adiabatic_gamma_ion = std::stod(val);
 
     // Store cut parameters
     else if (key == "cut_rho_min")

--- a/src/input_reader/input_reader.hpp
+++ b/src/input_reader/input_reader.hpp
@@ -174,6 +174,7 @@ struct InputReader
   std::optional<double> plasma_w;
   std::optional<double> adiabatic_gamma_elec;
   std::optional<double> adiabatic_gamma_ion;
+  std::optional<bool> use_ipole_tpte;
 
   // Data - cut parameters
   std::optional<double> cut_rho_min;

--- a/src/input_reader/input_reader.hpp
+++ b/src/input_reader/input_reader.hpp
@@ -163,6 +163,10 @@ struct InputReader
   std::optional<double> plasma_mu;
   std::optional<double> plasma_ne_ni;
   std::optional<PlasmaModel> plasma_model;
+  std::optional<bool> plasma_use_p;
+  std::optional<double> plasma_gamma;
+  std::optional<double> plasma_gamma_i;
+  std::optional<double> plasma_gamma_e;
   std::optional<double> plasma_rat_low;
   std::optional<double> plasma_rat_high;
   std::optional<double> plasma_power_frac;
@@ -172,9 +176,6 @@ struct InputReader
   std::optional<double> plasma_kappa_frac;
   std::optional<double> plasma_kappa;
   std::optional<double> plasma_w;
-  std::optional<double> adiabatic_gamma_elec;
-  std::optional<double> adiabatic_gamma_ion;
-  std::optional<bool> use_ipole_tpte;
 
   // Data - cut parameters
   std::optional<double> cut_rho_min;

--- a/src/input_reader/input_reader.hpp
+++ b/src/input_reader/input_reader.hpp
@@ -172,6 +172,8 @@ struct InputReader
   std::optional<double> plasma_kappa_frac;
   std::optional<double> plasma_kappa;
   std::optional<double> plasma_w;
+  std::optional<double> adiabatic_gamma_elec;
+  std::optional<double> adiabatic_gamma_ion;
 
   // Data - cut parameters
   std::optional<double> cut_rho_min;

--- a/src/radiation_integrator/radiation_geometry.cpp
+++ b/src/radiation_integrator/radiation_geometry.cpp
@@ -31,9 +31,12 @@ double RadiationIntegrator::RadialGeodesicCoordinate(double x, double y, double 
 //   *p_x1, *p_x2, *p_x3: Cartesian Kerr-Schild coordinates
 // Outputs:
 //   *p_x1, *p_x2, *p_x3: simulation coordinates
+// Notes:
+//   When simulation_coord == Coordinates::fmks, this still translates from CKS into
+//     SKS rather than FMKS. Recall the interpolation grid takes as input SKS.
 void RadiationIntegrator::ConvertFromCKS(double *p_x1, double *p_x2, double *p_x3) const
 {
-  if (simulation_coord == Coordinates::sks)
+  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
   {
     double x = *p_x1;
     double y = *p_x2;
@@ -66,8 +69,9 @@ void RadiationIntegrator::ConvertFromCKS(double *p_x1, double *p_x2, double *p_x
 void RadiationIntegrator::CoordinateJacobian(double x, double y, double z, double jacobian[4][4])
     const
 {
+  // TODO: maybe change this? figure out how it is used.
   // Calculate Jacobian for spherical Kerr-Schild simulation
-  if (simulation_coord == Coordinates::sks)
+  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
   {
     // Calculate spherical position
     double a2 = bh_a * bh_a;
@@ -419,7 +423,7 @@ void RadiationIntegrator::CovariantSimulationMetric(double x, double y, double z
     const
 {
   // Calculate spherical Kerr-Schild metric
-  if (simulation_coord == Coordinates::sks)
+  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
   {
     // Calculate useful quantities
     double a2 = bh_a * bh_a;
@@ -500,7 +504,7 @@ void RadiationIntegrator::ContravariantSimulationMetric(double x, double y, doub
     double gcon[4][4]) const
 {
   // Calculate spherical Kerr-Schild metric
-  if (simulation_coord == Coordinates::sks)
+  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
   {
     // Calculate useful quantities
     double a2 = bh_a * bh_a;

--- a/src/radiation_integrator/radiation_geometry.cpp
+++ b/src/radiation_integrator/radiation_geometry.cpp
@@ -32,11 +32,11 @@ double RadiationIntegrator::RadialGeodesicCoordinate(double x, double y, double 
 // Outputs:
 //   *p_x1, *p_x2, *p_x3: simulation coordinates
 // Notes:
-//   When simulation_coord == Coordinates::fmks, this still translates from CKS into
-//     SKS rather than FMKS. Recall the interpolation grid takes as input SKS.
+//   When simulation_coord == Coordinates::fmks, this still translates from CKS into SKS rather than
+//       FMKS. Recall the interpolation grid takes as input SKS.
 void RadiationIntegrator::ConvertFromCKS(double *p_x1, double *p_x2, double *p_x3) const
 {
-  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
+  if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
   {
     double x = *p_x1;
     double y = *p_x2;
@@ -69,9 +69,30 @@ void RadiationIntegrator::ConvertFromCKS(double *p_x1, double *p_x2, double *p_x
 void RadiationIntegrator::CoordinateJacobian(double x, double y, double z, double jacobian[4][4])
     const
 {
+  // Calculate Jacobian for Cartesian Kerr-Schild simulation
+  if (simulation_coord == Coordinates::cks)
+  {
+    jacobian[0][0] = 1.0;
+    jacobian[0][1] = 0.0;
+    jacobian[0][2] = 0.0;
+    jacobian[0][3] = 0.0;
+    jacobian[1][0] = 0.0;
+    jacobian[1][1] = 1.0;
+    jacobian[1][2] = 0.0;
+    jacobian[1][3] = 0.0;
+    jacobian[2][0] = 0.0;
+    jacobian[2][1] = 0.0;
+    jacobian[2][2] = 1.0;
+    jacobian[2][3] = 0.0;
+    jacobian[3][0] = 0.0;
+    jacobian[3][1] = 0.0;
+    jacobian[3][2] = 0.0;
+    jacobian[3][3] = 1.0;
+  }
+
   // TODO: maybe change this? figure out how it is used.
   // Calculate Jacobian for spherical Kerr-Schild simulation
-  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
+  else if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
   {
     // Calculate spherical position
     double a2 = bh_a * bh_a;
@@ -101,27 +122,6 @@ void RadiationIntegrator::CoordinateJacobian(double x, double y, double z, doubl
     jacobian[3][1] = cth;
     jacobian[3][2] = -r * sth;
     jacobian[3][3] = 0.0;
-  }
-
-  // Calculate Jacobian for Cartesian Kerr-Schild simulation
-  else if (simulation_coord == Coordinates::cks)
-  {
-    jacobian[0][0] = 1.0;
-    jacobian[0][1] = 0.0;
-    jacobian[0][2] = 0.0;
-    jacobian[0][3] = 0.0;
-    jacobian[1][0] = 0.0;
-    jacobian[1][1] = 1.0;
-    jacobian[1][2] = 0.0;
-    jacobian[1][3] = 0.0;
-    jacobian[2][0] = 0.0;
-    jacobian[2][1] = 0.0;
-    jacobian[2][2] = 1.0;
-    jacobian[2][3] = 0.0;
-    jacobian[3][0] = 0.0;
-    jacobian[3][1] = 0.0;
-    jacobian[3][2] = 0.0;
-    jacobian[3][3] = 1.0;
   }
   return;
 }
@@ -422,40 +422,8 @@ void RadiationIntegrator::GeodesicConnection(double x, double y, double z,
 void RadiationIntegrator::CovariantSimulationMetric(double x, double y, double z, double gcov[4][4])
     const
 {
-  // Calculate spherical Kerr-Schild metric
-  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
-  {
-    // Calculate useful quantities
-    double a2 = bh_a * bh_a;
-    double rr2 = x * x + y * y + z * z;
-    double r2 = 0.5 * (rr2 - a2 + std::hypot(rr2 - a2, 2.0 * bh_a * z));
-    double r = std::sqrt(r2);
-    double cth = z / r;
-    double cth2 = cth * cth;
-    double sth2 = 1.0 - cth2;
-    double sigma = r2 + a2 * cth2;
-
-    // Calculate metric components
-    gcov[0][0] = -(1.0 - 2.0 * bh_m * r / sigma);
-    gcov[0][1] = 2.0 * bh_m * r / sigma;
-    gcov[0][2] = 0.0;
-    gcov[0][3] = -2.0 * bh_m * bh_a * r * sth2 / sigma;
-    gcov[1][0] = 2.0 * bh_m * r / sigma;
-    gcov[1][1] = 1.0 + 2.0 * bh_m * r / sigma;
-    gcov[1][2] = 0.0;
-    gcov[1][3] = -(1.0 + 2.0 * bh_m * r / sigma) * bh_a * sth2;
-    gcov[2][0] = 0.0;
-    gcov[2][1] = 0.0;
-    gcov[2][2] = sigma;
-    gcov[2][3] = 0.0;
-    gcov[3][0] = -2.0 * bh_m * bh_a * r * sth2 / sigma;
-    gcov[3][1] = -(1.0 + 2.0 * bh_m * r / sigma) * bh_a * sth2;
-    gcov[3][2] = 0.0;
-    gcov[3][3] = (r2 + a2 + 2.0 * bh_m * a2 * r * sth2 / sigma) * sth2;
-  }
-
   // Calculate Cartesian Kerr-Schild metric
-  else if (simulation_coord == Coordinates::cks)
+  if (simulation_coord == Coordinates::cks)
   {
     // Calculate useful quantities
     double a2 = bh_a * bh_a;
@@ -488,6 +456,38 @@ void RadiationIntegrator::CovariantSimulationMetric(double x, double y, double z
     gcov[3][2] = f * l_3 * l_2;
     gcov[3][3] = f * l_3 * l_3 + 1.0;
   }
+
+  // Calculate spherical Kerr-Schild metric
+  else if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
+  {
+    // Calculate useful quantities
+    double a2 = bh_a * bh_a;
+    double rr2 = x * x + y * y + z * z;
+    double r2 = 0.5 * (rr2 - a2 + std::hypot(rr2 - a2, 2.0 * bh_a * z));
+    double r = std::sqrt(r2);
+    double cth = z / r;
+    double cth2 = cth * cth;
+    double sth2 = 1.0 - cth2;
+    double sigma = r2 + a2 * cth2;
+
+    // Calculate metric components
+    gcov[0][0] = -(1.0 - 2.0 * bh_m * r / sigma);
+    gcov[0][1] = 2.0 * bh_m * r / sigma;
+    gcov[0][2] = 0.0;
+    gcov[0][3] = -2.0 * bh_m * bh_a * r * sth2 / sigma;
+    gcov[1][0] = 2.0 * bh_m * r / sigma;
+    gcov[1][1] = 1.0 + 2.0 * bh_m * r / sigma;
+    gcov[1][2] = 0.0;
+    gcov[1][3] = -(1.0 + 2.0 * bh_m * r / sigma) * bh_a * sth2;
+    gcov[2][0] = 0.0;
+    gcov[2][1] = 0.0;
+    gcov[2][2] = sigma;
+    gcov[2][3] = 0.0;
+    gcov[3][0] = -2.0 * bh_m * bh_a * r * sth2 / sigma;
+    gcov[3][1] = -(1.0 + 2.0 * bh_m * r / sigma) * bh_a * sth2;
+    gcov[3][2] = 0.0;
+    gcov[3][3] = (r2 + a2 + 2.0 * bh_m * a2 * r * sth2 / sigma) * sth2;
+  }
   return;
 }
 
@@ -503,41 +503,8 @@ void RadiationIntegrator::CovariantSimulationMetric(double x, double y, double z
 void RadiationIntegrator::ContravariantSimulationMetric(double x, double y, double z,
     double gcon[4][4]) const
 {
-  // Calculate spherical Kerr-Schild metric
-  if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
-  {
-    // Calculate useful quantities
-    double a2 = bh_a * bh_a;
-    double rr2 = x * x + y * y + z * z;
-    double r2 = 0.5 * (rr2 - a2 + std::hypot(rr2 - a2, 2.0 * bh_a * z));
-    double r = std::sqrt(r2);
-    double cth = z / r;
-    double cth2 = cth * cth;
-    double sth2 = 1.0 - cth2;
-    double delta = r2 - 2.0 * bh_m * r + a2;
-    double sigma = r2 + a2 * cth2;
-
-    // Calculate metric components
-    gcon[0][0] = -(1.0 + 2.0 * bh_m * r / sigma);
-    gcon[0][1] = 2.0 * bh_m * r / sigma;
-    gcon[0][2] = 0.0;
-    gcon[0][3] = 0.0;
-    gcon[1][0] = 2.0 * bh_m * r / sigma;
-    gcon[1][1] = delta / sigma;
-    gcon[1][2] = 0.0;
-    gcon[1][3] = bh_a / sigma;
-    gcon[2][0] = 0.0;
-    gcon[2][1] = 0.0;
-    gcon[2][2] = 1.0 / sigma;
-    gcon[2][3] = 0.0;
-    gcon[3][0] = 0.0;
-    gcon[3][1] = bh_a / sigma;
-    gcon[3][2] = 0.0;
-    gcon[3][3] = 1.0 / (sigma * sth2);
-  }
-
   // Calculate Cartesian Kerr-Schild metric
-  else if (simulation_coord == Coordinates::cks)
+  if (simulation_coord == Coordinates::cks)
   {
     // Calculate useful quantities
     double a2 = bh_a * bh_a;
@@ -569,6 +536,39 @@ void RadiationIntegrator::ContravariantSimulationMetric(double x, double y, doub
     gcon[3][1] = -f * l3 * l1;
     gcon[3][2] = -f * l3 * l2;
     gcon[3][3] = -f * l3 * l3 + 1.0;
+  }
+
+  // Calculate spherical Kerr-Schild metric
+  else if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
+  {
+    // Calculate useful quantities
+    double a2 = bh_a * bh_a;
+    double rr2 = x * x + y * y + z * z;
+    double r2 = 0.5 * (rr2 - a2 + std::hypot(rr2 - a2, 2.0 * bh_a * z));
+    double r = std::sqrt(r2);
+    double cth = z / r;
+    double cth2 = cth * cth;
+    double sth2 = 1.0 - cth2;
+    double delta = r2 - 2.0 * bh_m * r + a2;
+    double sigma = r2 + a2 * cth2;
+
+    // Calculate metric components
+    gcon[0][0] = -(1.0 + 2.0 * bh_m * r / sigma);
+    gcon[0][1] = 2.0 * bh_m * r / sigma;
+    gcon[0][2] = 0.0;
+    gcon[0][3] = 0.0;
+    gcon[1][0] = 2.0 * bh_m * r / sigma;
+    gcon[1][1] = delta / sigma;
+    gcon[1][2] = 0.0;
+    gcon[1][3] = bh_a / sigma;
+    gcon[2][0] = 0.0;
+    gcon[2][1] = 0.0;
+    gcon[2][2] = 1.0 / sigma;
+    gcon[2][3] = 0.0;
+    gcon[3][0] = 0.0;
+    gcon[3][1] = bh_a / sigma;
+    gcon[3][2] = 0.0;
+    gcon[3][3] = 1.0 / (sigma * sth2);
   }
   return;
 }

--- a/src/radiation_integrator/radiation_geometry.cpp
+++ b/src/radiation_integrator/radiation_geometry.cpp
@@ -90,7 +90,6 @@ void RadiationIntegrator::CoordinateJacobian(double x, double y, double z, doubl
     jacobian[3][3] = 1.0;
   }
 
-  // TODO: maybe change this? figure out how it is used.
   // Calculate Jacobian for spherical Kerr-Schild simulation
   else if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
   {

--- a/src/radiation_integrator/radiation_integrator.cpp
+++ b/src/radiation_integrator/radiation_integrator.cpp
@@ -277,13 +277,9 @@ RadiationIntegrator::RadiationIntegrator(const InputReader *p_input_reader,
     plasma_model = p_input_reader->plasma_model.value();
     if (plasma_model == PlasmaModel::ti_te_beta)
     {
+      plasma_use_p = p_input_reader->plasma_use_p.value();
       plasma_rat_low = p_input_reader->plasma_rat_low.value();
       plasma_rat_high = p_input_reader->plasma_rat_high.value();
-    }
-    use_ipole_tpte = false;
-    if (p_input_reader->use_ipole_tpte.has_value() && p_input_reader->use_ipole_tpte.value())
-    {
-      use_ipole_tpte = p_input_reader->use_ipole_tpte.value();
     }
     plasma_power_frac = p_input_reader->plasma_power_frac.value();
     if (plasma_power_frac < 0.0 or plasma_power_frac > 1.0)

--- a/src/radiation_integrator/radiation_integrator.cpp
+++ b/src/radiation_integrator/radiation_integrator.cpp
@@ -280,6 +280,11 @@ RadiationIntegrator::RadiationIntegrator(const InputReader *p_input_reader,
       plasma_rat_low = p_input_reader->plasma_rat_low.value();
       plasma_rat_high = p_input_reader->plasma_rat_high.value();
     }
+    use_ipole_tpte = false;
+    if (p_input_reader->use_ipole_tpte.has_value() && p_input_reader->use_ipole_tpte.value())
+    {
+      use_ipole_tpte = p_input_reader->use_ipole_tpte.value();
+    }
     plasma_power_frac = p_input_reader->plasma_power_frac.value();
     if (plasma_power_frac < 0.0 or plasma_power_frac > 1.0)
       BlacklightWarning("Fraction of power-law electrons outside [0, 1].");

--- a/src/radiation_integrator/radiation_integrator.hpp
+++ b/src/radiation_integrator/radiation_integrator.hpp
@@ -217,6 +217,11 @@ struct RadiationIntegrator
   int ind_uu1, ind_uu2, ind_uu3;
   int ind_bb1, ind_bb2, ind_bb3;
 
+  // Interpolation grid data
+  Array<double> sks_map;
+  Array<double> simulation_bounds;
+  double sks_map_rin, sks_map_rout, sks_map_dr, sks_map_dtheta;
+
   // Sample data
   Array<int> *sample_inds = nullptr;
   Array<double> *sample_fracs = nullptr;

--- a/src/radiation_integrator/radiation_integrator.hpp
+++ b/src/radiation_integrator/radiation_integrator.hpp
@@ -218,9 +218,9 @@ struct RadiationIntegrator
   int ind_bb1, ind_bb2, ind_bb3;
 
   // Interpolation grid data
-  Array<double> sks_map;
+  double sks_map_r_in, sks_map_r_out, sks_map_dr, sks_map_dtheta;
   Array<double> simulation_bounds;
-  double sks_map_rin, sks_map_rout, sks_map_dr, sks_map_dtheta;
+  Array<double> sks_map;
 
   // Sample data
   Array<int> *sample_inds = nullptr;

--- a/src/radiation_integrator/radiation_integrator.hpp
+++ b/src/radiation_integrator/radiation_integrator.hpp
@@ -125,6 +125,10 @@ struct RadiationIntegrator
   double plasma_ne_ni;
   double plasma_thermal_frac;
   PlasmaModel plasma_model;
+  bool plasma_use_p;
+  double plasma_gamma;
+  double plasma_gamma_i;
+  double plasma_gamma_e;
   double plasma_rat_low;
   double plasma_rat_high;
   double plasma_power_frac;
@@ -134,12 +138,6 @@ struct RadiationIntegrator
   double plasma_kappa_frac;
   double plasma_kappa;
   double plasma_w;
-
-  // Input data - thermodynamics model
-  bool use_ipole_tpte;
-  double adiabatic_gamma;
-  double adiabatic_gamma_elec;
-  double adiabatic_gamma_ion;
 
   // Input data - cut parameters
   double cut_rho_min;

--- a/src/radiation_integrator/radiation_integrator.hpp
+++ b/src/radiation_integrator/radiation_integrator.hpp
@@ -135,6 +135,12 @@ struct RadiationIntegrator
   double plasma_kappa;
   double plasma_w;
 
+  // Input data - thermodynamics model
+  bool use_ipole_tpte;
+  double adiabatic_gamma;
+  double adiabatic_gamma_elec;
+  double adiabatic_gamma_ion;
+
   // Input data - cut parameters
   double cut_rho_min;
   double cut_rho_max;

--- a/src/radiation_integrator/simulation_coefficients.cpp
+++ b/src/radiation_integrator/simulation_coefficients.cpp
@@ -334,22 +334,17 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         double theta_e = std::numeric_limits<double>::quiet_NaN();
         if (plasma_thermal_frac != 0.0 and plasma_model == PlasmaModel::ti_te_beta)
         {
-          double tt_rat = (plasma_rat_high + plasma_rat_low * beta_inv * beta_inv)
+          double tti_tte = (plasma_rat_high + plasma_rat_low * beta_inv * beta_inv)
               / (1.0 + beta_inv * beta_inv);
-          if (use_ipole_tpte)
-          {
-            double theta_e_unit = (adiabatic_gamma_elec - 1.0) * (adiabatic_gamma_ion - 1.0);
-            theta_e_unit /= (adiabatic_gamma_ion - 1.0) + (adiabatic_gamma_elec - 1.0) * tt_rat;
-            theta_e_unit *= Physics::m_p / Physics::m_e;
-            theta_e = theta_e_unit * pgas / rho / (adiabatic_gamma - 1.0);
-            kb_tt_e_cgs = theta_e * Physics::m_e * Physics::c * Physics::c;
-          }
+          double kb_tt_tot_cgs = plasma_mu * Physics::m_p * pgas_cgs / rho_cgs;
+          if (plasma_use_p)
+            kb_tt_e_cgs = (1.0 + plasma_ne_ni) / (tti_tte + plasma_ne_ni) * kb_tt_tot_cgs;
           else
           {
-            double kb_tt_tot_cgs = plasma_mu * Physics::m_p * pgas_cgs / rho_cgs;
-            kb_tt_e_cgs = (plasma_ne_ni + 1.0) / (plasma_ne_ni + tt_rat) * kb_tt_tot_cgs;
-            theta_e = kb_tt_e_cgs / (Physics::m_e * Physics::c * Physics::c);
+            kb_tt_e_cgs = (1.0 + plasma_ne_ni) * kb_tt_tot_cgs / (plasma_gamma - 1.0);
+            kb_tt_e_cgs /= tti_tte / (plasma_gamma_i - 1.0) + plasma_ne_ni / (plasma_gamma_e - 1.0);
           }
+          theta_e = kb_tt_e_cgs / (Physics::m_e * Physics::c * Physics::c);
         }
 
         // Calculate electron temperature for given electron entropy (E2 13)

--- a/src/radiation_integrator/simulation_coefficients.cpp
+++ b/src/radiation_integrator/simulation_coefficients.cpp
@@ -292,7 +292,6 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         // Calculate simulation metric
         CovariantSimulationMetric(x1, x2, x3, gcov_sim);
         ContravariantSimulationMetric(x1, x2, x3, gcon_sim);
-        // TODO check two above are in SKS
 
         // Calculate simulation velocity
         double uu0_sim = std::sqrt(1.0 + gcov_sim[1][1] * uu1_sim * uu1_sim
@@ -477,7 +476,6 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
             j_i_val = coefficient * var_a * var_c * var_c;
             if (image_light or image_emission or image_emission_ave)
               j_i[adaptive_level](l,m,n) = j_i_val;
-
             if (image_light and image_polarization)
             {
               double var_d = (7.0 * std::pow(theta_e, 0.96) + 35.0)

--- a/src/radiation_integrator/simulation_coefficients.cpp
+++ b/src/radiation_integrator/simulation_coefficients.cpp
@@ -336,9 +336,20 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         {
           double tt_rat = (plasma_rat_high + plasma_rat_low * beta_inv * beta_inv)
               / (1.0 + beta_inv * beta_inv);
-          double kb_tt_tot_cgs = plasma_mu * Physics::m_p * pgas_cgs / rho_cgs;
-          kb_tt_e_cgs = (plasma_ne_ni + 1.0) / (plasma_ne_ni + tt_rat) * kb_tt_tot_cgs;
-          theta_e = kb_tt_e_cgs / (Physics::m_e * Physics::c * Physics::c);
+          if (use_ipole_tpte)
+          {
+            double theta_e_unit = (adiabatic_gamma_elec - 1.0) * (adiabatic_gamma_ion - 1.0);
+            theta_e_unit /= (adiabatic_gamma_ion - 1.0) + (adiabatic_gamma_elec - 1.0) * tt_rat;
+            theta_e_unit *= Physics::m_p / Physics::m_e;
+            theta_e = theta_e_unit * pgas / rho / (adiabatic_gamma - 1.0);
+            kb_tt_e_cgs = theta_e * Physics::m_e * Physics::c * Physics::c;
+          }
+          else
+          {
+            double kb_tt_tot_cgs = plasma_mu * Physics::m_p * pgas_cgs / rho_cgs;
+            kb_tt_e_cgs = (plasma_ne_ni + 1.0) / (plasma_ne_ni + tt_rat) * kb_tt_tot_cgs;
+            theta_e = kb_tt_e_cgs / (Physics::m_e * Physics::c * Physics::c);
+          }
         }
 
         // Calculate electron temperature for given electron entropy (E2 13)

--- a/src/radiation_integrator/simulation_coefficients.cpp
+++ b/src/radiation_integrator/simulation_coefficients.cpp
@@ -292,6 +292,13 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         // Calculate simulation metric
         CovariantSimulationMetric(x1, x2, x3, gcov_sim);
         ContravariantSimulationMetric(x1, x2, x3, gcon_sim);
+        // TODO check two above are in SKS
+        //
+        //fprintf(stderr, "coord is %g %g %g\n", x1, x2, x3);
+        double ttr = x1;
+        double tth = x2;
+        double ttp = x3;
+        ConvertFromCKS(&ttr, &tth, &ttp);
 
         // Calculate simulation velocity
         double uu0_sim = std::sqrt(1.0 + gcov_sim[1][1] * uu1_sim * uu1_sim
@@ -328,7 +335,7 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         double bb_cgs = std::sqrt(b_sq) * b_unit;
         double sigma = b_sq / rho;
         double beta_inv = b_sq / (2.0 * pgas);
-
+        
         // Calculate electron temperature for model with T_i/T_e a function of beta (E1 1)
         double kb_tt_e_cgs = std::numeric_limits<double>::quiet_NaN();
         double theta_e = std::numeric_limits<double>::quiet_NaN();
@@ -476,6 +483,7 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
             j_i_val = coefficient * var_a * var_c * var_c;
             if (image_light or image_emission or image_emission_ave)
               j_i[adaptive_level](l,m,n) = j_i_val;
+
             if (image_light and image_polarization)
             {
               double var_d = (7.0 * std::pow(theta_e, 0.96) + 35.0)

--- a/src/radiation_integrator/simulation_coefficients.cpp
+++ b/src/radiation_integrator/simulation_coefficients.cpp
@@ -289,30 +289,10 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         double n_cgs = rho_cgs / (plasma_mu * Physics::m_p);
         double n_e_cgs = n_cgs / (1.0 + 1.0 / plasma_ne_ni);
 
-        // TODO remove
-        //fprintf(stderr, "coord %d %d %g %g %g\n", m, n, x1, x2, x3);
-        //fprintf(stderr, "rho %d %d %g %g %g %g\n", m, n, rho_cgs, pgas_cgs, n_cgs, n_e_cgs);
-
         // Calculate simulation metric
         CovariantSimulationMetric(x1, x2, x3, gcov_sim);
         ContravariantSimulationMetric(x1, x2, x3, gcon_sim);
         // TODO check two above are in SKS
-        //
-        //fprintf(stderr, "coord is %g %g %g\n", x1, x2, x3);
-        if (0==1) {
-          double ttr = x1;
-          double tth = x2;
-          double ttp = x3;
-          ConvertFromCKS(&ttr, &tth, &ttp);
-          double idbl, jdbl;
-          double di = std::modf((ttr - sks_map_rin) / sks_map_dr, &idbl);
-          double dj = std::modf(tth / sks_map_dtheta, &jdbl);
-          int i = static_cast<int>(idbl);
-          int j = static_cast<int>(jdbl);
-          double fmks_x1 = sks_map(0, j, i)*(1-di) + di*sks_map(0, j, i+1);
-          double fmks_x2 = sks_map(1, j+1, i)*(1-dj) + dj*sks_map(1, j+1, i);
-          fprintf(stderr, "rhpcoord %d %d %g %g %g %g %g\n", m, n, ttr, tth, ttp, fmks_x1, fmks_x2);
-        }
 
         // Calculate simulation velocity
         double uu0_sim = std::sqrt(1.0 + gcov_sim[1][1] * uu1_sim * uu1_sim
@@ -350,15 +330,6 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
         double sigma = b_sq / rho;
         double beta_inv = b_sq / (2.0 * pgas);
 
-        // TODO remove
-        /*
-        fprintf(stderr, "prims %d %d %g %g %g %g %g %g %g %g %g\n", m, n, rho, pgas, uu1_sim, uu2_sim, uu3_sim, bb1_sim, bb2_sim, bb3_sim, b_sq);
-
-        fprintf(stderr, "fourv %d %d %g %g %g %g %g %g %g %g\n", m, n, ucon_sim[0], ucon_sim[1], ucon_sim[2], ucon_sim[3], bcon_sim[0], bcon_sim[1], bcon_sim[2], bcon_sim[3]);
-
-        fprintf(stderr, "units %g %g %g\n", d_unit / (plasma_mu * Physics::m_p) / (1.0 + 1.0 / plasma_ne_ni), n_e_cgs / rho, b_unit);
-         */
-
         // Calculate electron temperature for model with T_i/T_e a function of beta (E1 1)
         double kb_tt_e_cgs = std::numeric_limits<double>::quiet_NaN();
         double theta_e = std::numeric_limits<double>::quiet_NaN();
@@ -380,9 +351,6 @@ void RadiationIntegrator::CalculateSimulationCoefficients()
           theta_e = 1.0 / 5.0 * (std::sqrt(1.0 + 25.0 * rho_kappa_e_cbrt * rho_kappa_e_cbrt) - 1.0);
           kb_tt_e_cgs = theta_e * Physics::m_e * Physics::c * Physics::c;
         }
-
-        // TODO remove
-        //fprintf(stderr, "aux %d %d %g %g %g %g\n", m, n, bb_cgs, sigma, beta_inv, theta_e);
 
         // Skip coupling based on cell values
         if ((cut_rho_min >= 0.0 and rho_cgs < cut_rho_min)

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -1041,8 +1041,8 @@ void RadiationIntegrator::SampleSimulation()
 //   If the requested cell is not on the grid, values are copied from the unique cell on the grid
 //       closest to the appropriate ghost cell, effectively resulting in constant (rather than
 //       linear) extrapolation near the edges of the grid.
-//   In the case of simulation_coord == Coordinates::sks or Coordinates::fmks, neighboring blocks 
-//       are understood to cross the periodic boundary in x^3 (phi), but the domain is not stitched 
+//   In the case of simulation_coord being Coordinates::sks or Coordinates::fmks, neighboring blocks
+//       are understood to cross the periodic boundary in x^3 (phi), but the domain is not stitched
 //       together at the poles.
 void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, int j_c, int i_c,
     double x3, double x2, double x1, int inds[4])

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -46,6 +46,7 @@ void RadiationIntegrator::ObtainGridData()
   x1v = p_simulation_reader->x1v;
   x2v = p_simulation_reader->x2v;
   x3v = p_simulation_reader->x3v;
+  simulation_bounds = p_simulation_reader->simulation_bounds;
 
   // Copy time
   time = p_simulation_reader->time;
@@ -63,6 +64,13 @@ void RadiationIntegrator::ObtainGridData()
   ind_bb1 = p_simulation_reader->ind_bb1;
   ind_bb2 = p_simulation_reader->ind_bb2;
   ind_bb3 = p_simulation_reader->ind_bb3;
+
+  // Copy coordinate interpolation map
+  sks_map_rin = p_simulation_reader->sks_map_rin;
+  sks_map_rout = p_simulation_reader->sks_map_rout;
+  sks_map_dr = p_simulation_reader->sks_map_dr;
+  sks_map_dtheta = p_simulation_reader->sks_map_dtheta;
+  sks_map = p_simulation_reader->sks_map;
 
   // Calculate maximum refinement level and number of blocks in x^3-direction at each level
   if (simulation_format == SimulationFormat::athena and simulation_coord == Coordinates::sks
@@ -173,6 +181,15 @@ void RadiationIntegrator::CalculateSimulationSampling(int snapshot)
     double x3_min_block = x3f(b,0);
     double x3_max_block = x3f(b,n_k);
 
+    if (simulation_coord == Coordinates::fmks) {
+      x1_min_block = simulation_bounds(0);
+      x1_max_block = simulation_bounds(1);
+      x2_min_block = simulation_bounds(2);
+      x2_max_block = simulation_bounds(3);
+      x3_min_block = simulation_bounds(4);
+      x3_max_block = simulation_bounds(5);
+    }
+
     // Resample cell data onto geodesics
     #pragma omp for schedule(static) reduction(+: num_extrap_camera_small, \
         num_extrap_camera_large, num_extrap_source_small, num_extrap_source_large) reduction(max: \
@@ -185,7 +202,7 @@ void RadiationIntegrator::CalculateSimulationSampling(int snapshot)
 
       // Set NaN fallback values if geodesic poorly terminated
       if (fallback_nan and sample_flags[adaptive_level](m))
-      {
+      { 
         for (int n = 0; n < num_steps; n++)
           sample_nan[adaptive_level](m,n) = true;
         continue;
@@ -369,99 +386,147 @@ void RadiationIntegrator::CalculateSimulationSampling(int snapshot)
           x3_max_block = x3_max_temp;
         }
 
-        // Determine cell
-        for (i = 0; i < n_i; i++)
-          if (x1f(b,i+1) >= x1)
-            break;
-        for (j = 0; j < n_j; j++)
-          if (x2f(b,j+1) >= x2)
-            break;
-        for (k = 0; k < n_k; k++)
-          if (x3f(b,k+1) >= x3)
-            break;
 
-        // Prepare to sample values without interpolation
-        if (not simulation_interp)
+        // When the simulation uses Coordinates::fmks (or really any interpolated
+        // set of coordinates) we have to fall back on finding indices plus fractions
+        // the "old" way. This could be modified in the future to be more permissive.
+        if (simulation_coord == Coordinates::fmks)
         {
-          sample_inds[adaptive_level](m,n,0) = b;
-          sample_inds[adaptive_level](m,n,1) = k;
-          sample_inds[adaptive_level](m,n,2) = j;
-          sample_inds[adaptive_level](m,n,3) = i;
-          if (slow_light_on)
-            sample_inds[adaptive_level](m,n,4) = t_ind;
-          if (slow_light_on and slow_interp)
-            sample_fracs[adaptive_level](m,n,0) = t_frac;
+            // get location of coordinate point in sks map with fractional offset
+            double idbl, jdbl;
+            double di = std::modf((x1 - sks_map_rin) / sks_map_dr, &idbl);
+            double dj = std::modf(x2 / sks_map_dtheta, &jdbl);
+            i = static_cast<int>(idbl);
+            j = static_cast<int>(jdbl);
+            double fmks_x1 = sks_map(0, j, i)*(1-di) + di*sks_map(0, j, i+1);
+            double fmks_x2 = sks_map(1, j+1, i)*(1-dj) + dj*sks_map(1, j+1, i);
+
+            // now get zone (+ fractional) within fluid file
+            double x1_0 = x1f(b,0);
+            double dx1 = x1f(b,1) - x1f(b,0);
+            double dx2 = x2f(b,1) - x2f(b,0);
+
+            di = std::modf((fmks_x1 - x1_0) / dx1, &idbl);
+            dj = std::modf(fmks_x2 / dx2, &jdbl);
+            i = static_cast<int>(idbl);
+            j = static_cast<int>(jdbl);
+
+            // can get phi coordinate as usual
+            for (k = 0; k < n_k; k++)
+              if (x3f(b,k+1) >= x3)
+                break;
+            int k_m = k == 0 or (k != n_k - 1 and x3 >= x3v(b,k)) ? k : k - 1;
+            double f_k = (x3 - x3v(b,k_m)) / (x3v(b,k_m+1) - x3v(b,k_m));
+
+            sample_inds[adaptive_level](m,n,0) = b;
+            sample_inds[adaptive_level](m,n,1) = k_m;
+            sample_inds[adaptive_level](m,n,2) = j;
+            sample_inds[adaptive_level](m,n,3) = i;
+            if (slow_light_on)
+              sample_inds[adaptive_level](m,n,4) = t_ind;
+            sample_fracs[adaptive_level](m,n,0) = f_k;
+            sample_fracs[adaptive_level](m,n,1) = dj;
+            sample_fracs[adaptive_level](m,n,2) = di;
+            if (slow_light_on and slow_interp)
+              sample_fracs[adaptive_level](m,n,3) = t_frac;
         }
 
-        // Prepare to sample values with intrablock interpolation
-        else if (not ((simulation_format == SimulationFormat::athena
-            or simulation_format == SimulationFormat::athenak) and simulation_block_interp))
-        {
-          int i_m = i == 0 or (i != n_i - 1 and x1 >= x1v(b,i)) ? i : i - 1;
-          int j_m = j == 0 or (j != n_j - 1 and x2 >= x2v(b,j)) ? j : j - 1;
-          int k_m = k == 0 or (k != n_k - 1 and x3 >= x3v(b,k)) ? k : k - 1;
-          double f_i = (x1 - x1v(b,i_m)) / (x1v(b,i_m+1) - x1v(b,i_m));
-          double f_j = (x2 - x2v(b,j_m)) / (x2v(b,j_m+1) - x2v(b,j_m));
-          double f_k = (x3 - x3v(b,k_m)) / (x3v(b,k_m+1) - x3v(b,k_m));
-          sample_inds[adaptive_level](m,n,0) = b;
-          sample_inds[adaptive_level](m,n,1) = k_m;
-          sample_inds[adaptive_level](m,n,2) = j_m;
-          sample_inds[adaptive_level](m,n,3) = i_m;
-          if (slow_light_on)
-            sample_inds[adaptive_level](m,n,4) = t_ind;
-          sample_fracs[adaptive_level](m,n,0) = f_k;
-          sample_fracs[adaptive_level](m,n,1) = f_j;
-          sample_fracs[adaptive_level](m,n,2) = f_i;
-          if (slow_light_on and slow_interp)
-            sample_fracs[adaptive_level](m,n,3) = t_frac;
-        }
-
-        // Prepare to sample values with interblock interpolation
         else
         {
-          // Determine indices to use for interpolation
-          int i_m = x1 >= x1v(b,i) ? i : i - 1;
-          int j_m = x2 >= x2v(b,j) ? j : j - 1;
-          int k_m = x3 >= x3v(b,k) ? k : k - 1;
-          int i_p = i_m + 1;
-          int j_p = j_m + 1;
-          int k_p = k_m + 1;
+          // Determine cell
+          for (i = 0; i < n_i; i++)
+            if (x1f(b,i+1) >= x1)
+              break;
+          for (j = 0; j < n_j; j++)
+            if (x2f(b,j+1) >= x2)
+              break;
+          for (k = 0; k < n_k; k++)
+            if (x3f(b,k+1) >= x3)
+              break;
 
-          // Calculate fractions to use in interpolation
-          double x1_m = i_m == -1 ? 2.0 * x1f(b,i) - x1v(b,i) : x1v(b,i_m);
-          double x2_m = j_m == -1 ? 2.0 * x2f(b,j) - x2v(b,j) : x2v(b,j_m);
-          double x3_m = k_m == -1 ? 2.0 * x3f(b,k) - x3v(b,k) : x3v(b,k_m);
-          double x1_p = i_p == n_i ? 2.0 * x1v(b,i+1) - x1v(b,i) : x1v(b,i_p);
-          double x2_p = j_p == n_j ? 2.0 * x2v(b,j+1) - x2v(b,j) : x2v(b,j_p);
-          double x3_p = k_p == n_k ? 2.0 * x3v(b,k+1) - x3v(b,k) : x3v(b,k_p);
-          double f_i = (x1 - x1_m) / (x1_p - x1_m);
-          double f_j = (x2 - x2_m) / (x2_p - x2_m);
-          double f_k = (x3 - x3_m) / (x3_p - x3_m);
-
-          // Find interpolation anchors
-          int inds[8][4];
-          FindNearbyInds(b, k_m, j_m, i_m, k, j, i, x3, x2, x1, inds[0]);
-          FindNearbyInds(b, k_m, j_m, i_p, k, j, i, x3, x2, x1, inds[1]);
-          FindNearbyInds(b, k_m, j_p, i_m, k, j, i, x3, x2, x1, inds[2]);
-          FindNearbyInds(b, k_m, j_p, i_p, k, j, i, x3, x2, x1, inds[3]);
-          FindNearbyInds(b, k_p, j_m, i_m, k, j, i, x3, x2, x1, inds[4]);
-          FindNearbyInds(b, k_p, j_m, i_p, k, j, i, x3, x2, x1, inds[5]);
-          FindNearbyInds(b, k_p, j_p, i_m, k, j, i, x3, x2, x1, inds[6]);
-          FindNearbyInds(b, k_p, j_p, i_p, k, j, i, x3, x2, x1, inds[7]);
-
-          // Store results
-          for (int p = 0; p < 8; p++)
+          // Prepare to sample values without interpolation
+          if (not simulation_interp)
           {
-            for (int q = 0; q < 4; q++)
-              sample_inds[adaptive_level](m,n,p,q) = inds[p][q];
+            sample_inds[adaptive_level](m,n,0) = b;
+            sample_inds[adaptive_level](m,n,1) = k;
+            sample_inds[adaptive_level](m,n,2) = j;
+            sample_inds[adaptive_level](m,n,3) = i;
             if (slow_light_on)
-              sample_inds[adaptive_level](m,n,p,4) = t_ind;
+              sample_inds[adaptive_level](m,n,4) = t_ind;
+            if (slow_light_on and slow_interp)
+              sample_fracs[adaptive_level](m,n,0) = t_frac;
           }
-          sample_fracs[adaptive_level](m,n,0) = f_k;
-          sample_fracs[adaptive_level](m,n,1) = f_j;
-          sample_fracs[adaptive_level](m,n,2) = f_i;
-          if (slow_light_on and slow_interp)
-            sample_fracs[adaptive_level](m,n,3) = t_frac;
+
+          // Prepare to sample values with intrablock interpolation
+          else if (not ((simulation_format == SimulationFormat::athena
+              or simulation_format == SimulationFormat::athenak) and simulation_block_interp))
+          {
+            int i_m = i == 0 or (i != n_i - 1 and x1 >= x1v(b,i)) ? i : i - 1;
+            int j_m = j == 0 or (j != n_j - 1 and x2 >= x2v(b,j)) ? j : j - 1;
+            int k_m = k == 0 or (k != n_k - 1 and x3 >= x3v(b,k)) ? k : k - 1;
+            double f_i = (x1 - x1v(b,i_m)) / (x1v(b,i_m+1) - x1v(b,i_m));
+            double f_j = (x2 - x2v(b,j_m)) / (x2v(b,j_m+1) - x2v(b,j_m));
+            double f_k = (x3 - x3v(b,k_m)) / (x3v(b,k_m+1) - x3v(b,k_m));
+            sample_inds[adaptive_level](m,n,0) = b;
+            sample_inds[adaptive_level](m,n,1) = k_m;
+            sample_inds[adaptive_level](m,n,2) = j_m;
+            sample_inds[adaptive_level](m,n,3) = i_m;
+            if (slow_light_on)
+              sample_inds[adaptive_level](m,n,4) = t_ind;
+            sample_fracs[adaptive_level](m,n,0) = f_k;
+            sample_fracs[adaptive_level](m,n,1) = f_j;
+            sample_fracs[adaptive_level](m,n,2) = f_i;
+            if (slow_light_on and slow_interp)
+              sample_fracs[adaptive_level](m,n,3) = t_frac;
+          }
+
+          // Prepare to sample values with interblock interpolation
+          else
+          {
+            // Determine indices to use for interpolation
+            int i_m = x1 >= x1v(b,i) ? i : i - 1;
+            int j_m = x2 >= x2v(b,j) ? j : j - 1;
+            int k_m = x3 >= x3v(b,k) ? k : k - 1;
+            int i_p = i_m + 1;
+            int j_p = j_m + 1;
+            int k_p = k_m + 1;
+
+            // Calculate fractions to use in interpolation
+            double x1_m = i_m == -1 ? 2.0 * x1f(b,i) - x1v(b,i) : x1v(b,i_m);
+            double x2_m = j_m == -1 ? 2.0 * x2f(b,j) - x2v(b,j) : x2v(b,j_m);
+            double x3_m = k_m == -1 ? 2.0 * x3f(b,k) - x3v(b,k) : x3v(b,k_m);
+            double x1_p = i_p == n_i ? 2.0 * x1v(b,i+1) - x1v(b,i) : x1v(b,i_p);
+            double x2_p = j_p == n_j ? 2.0 * x2v(b,j+1) - x2v(b,j) : x2v(b,j_p);
+            double x3_p = k_p == n_k ? 2.0 * x3v(b,k+1) - x3v(b,k) : x3v(b,k_p);
+            double f_i = (x1 - x1_m) / (x1_p - x1_m);
+            double f_j = (x2 - x2_m) / (x2_p - x2_m);
+            double f_k = (x3 - x3_m) / (x3_p - x3_m);
+
+            // Find interpolation anchors
+            int inds[8][4];
+            FindNearbyInds(b, k_m, j_m, i_m, k, j, i, x3, x2, x1, inds[0]);
+            FindNearbyInds(b, k_m, j_m, i_p, k, j, i, x3, x2, x1, inds[1]);
+            FindNearbyInds(b, k_m, j_p, i_m, k, j, i, x3, x2, x1, inds[2]);
+            FindNearbyInds(b, k_m, j_p, i_p, k, j, i, x3, x2, x1, inds[3]);
+            FindNearbyInds(b, k_p, j_m, i_m, k, j, i, x3, x2, x1, inds[4]);
+            FindNearbyInds(b, k_p, j_m, i_p, k, j, i, x3, x2, x1, inds[5]);
+            FindNearbyInds(b, k_p, j_p, i_m, k, j, i, x3, x2, x1, inds[6]);
+            FindNearbyInds(b, k_p, j_p, i_p, k, j, i, x3, x2, x1, inds[7]);
+
+            // Store results
+            for (int p = 0; p < 8; p++)
+            {
+              for (int q = 0; q < 4; q++)
+                sample_inds[adaptive_level](m,n,p,q) = inds[p][q];
+              if (slow_light_on)
+                sample_inds[adaptive_level](m,n,p,4) = t_ind;
+            }
+            sample_fracs[adaptive_level](m,n,0) = f_k;
+            sample_fracs[adaptive_level](m,n,1) = f_j;
+            sample_fracs[adaptive_level](m,n,2) = f_i;
+            if (slow_light_on and slow_interp)
+              sample_fracs[adaptive_level](m,n,3) = t_frac;
+          }
         }
       }
 
@@ -621,7 +686,7 @@ void RadiationIntegrator::SampleSimulation()
       }
 
       // Set nearest values
-      else if (not simulation_interp)
+      else if (not simulation_interp)  // TODO useful for bounds?
       {
         // Extract indices
         int b = sample_inds[adaptive_level](m,n,0);
@@ -976,8 +1041,9 @@ void RadiationIntegrator::SampleSimulation()
 //   If the requested cell is not on the grid, values are copied from the unique cell on the grid
 //       closest to the appropriate ghost cell, effectively resulting in constant (rather than
 //       linear) extrapolation near the edges of the grid.
-//   In the case of simulation_coord == Coordinates::sks, neighboring blocks are understood to cross
-//       the periodic boundary in x^3 (phi), but the domain is not stitched together at the poles.
+//   In the case of simulation_coord == Coordinates::sks or Coordinates::fmks, neighboring blocks 
+//       are understood to cross the periodic boundary in x^3 (phi), but the domain is not stitched 
+//       together at the poles.
 void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, int j_c, int i_c,
     double x3, double x2, double x1, int inds[4])
 {

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -117,10 +117,8 @@ void RadiationIntegrator::ObtainGridData()
 //   If slow_light_on == true, chooses from multiple available time slices for each point.
 //   If slow_light_on == true and slow_interp == true, prepares interpolation between adjacent (or
 //       sometimes identical) time slices.
-//   TODO: understand below
-//   When the simulation uses Coordinates::fmks (or really any interpolated set of coordinates) we
-//       have to fall back on finding indices plus fractions the "old" way. This could be modified
-//       in the future to be more permissive.
+//   When the simulation uses Coordinates::fmks, indices and fractions are found via simple scaling
+//       for uniform grids with no bounds checking.
 void RadiationIntegrator::CalculateSimulationSampling(int snapshot)
 {
   // Calculate time of snapshot

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -72,10 +72,10 @@ void RadiationIntegrator::ObtainGridData()
   simulation_bounds = p_simulation_reader->simulation_bounds;
   sks_map = p_simulation_reader->sks_map;
 
-  // Copy thermodynamic variables
-  adiabatic_gamma = p_simulation_reader->adiabatic_gamma;
-  adiabatic_gamma_elec = p_simulation_reader->adiabatic_gamma_elec;
-  adiabatic_gamma_ion = p_simulation_reader->adiabatic_gamma_ion;
+  // Copy input plasma parameters (possibly modified after contructors called)
+  plasma_gamma = p_simulation_reader->plasma_gamma;
+  plasma_gamma_i = p_simulation_reader->plasma_gamma_i;
+  plasma_gamma_e = p_simulation_reader->plasma_gamma_e;
 
   // Calculate maximum refinement level and number of blocks in x^3-direction at each level
   if (simulation_format == SimulationFormat::athena and simulation_coord == Coordinates::sks

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -202,7 +202,7 @@ void RadiationIntegrator::CalculateSimulationSampling(int snapshot)
 
       // Set NaN fallback values if geodesic poorly terminated
       if (fallback_nan and sample_flags[adaptive_level](m))
-      { 
+      {
         for (int n = 0; n < num_steps; n++)
           sample_nan[adaptive_level](m,n) = true;
         continue;

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -181,7 +181,8 @@ void RadiationIntegrator::CalculateSimulationSampling(int snapshot)
     double x3_min_block = x3f(b,0);
     double x3_max_block = x3f(b,n_k);
 
-    if (simulation_coord == Coordinates::fmks) {
+    if (simulation_coord == Coordinates::fmks)
+    {
       x1_min_block = simulation_bounds(0);
       x1_max_block = simulation_bounds(1);
       x2_min_block = simulation_bounds(2);
@@ -1086,7 +1087,8 @@ void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, in
     int location_k_alt = locations(b_alt,2);
 
     // Check x^1-direction
-    if (x1_off_grid and i != i_safe) {
+    if (x1_off_grid and i != i_safe)
+    {
       bool same_level_exists = level_alt == level;
       same_level_exists =
           same_level_exists and location_i_alt == (i == -1 ? location_i - 1 : location_i + 1);
@@ -1109,7 +1111,8 @@ void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, in
     }
 
     // Check x^2-direction
-    if (x2_off_grid and j != j_safe) {
+    if (x2_off_grid and j != j_safe)
+    {
       bool same_level_exists = level_alt == level;
       same_level_exists = same_level_exists and location_i_alt == location_i;
       same_level_exists =
@@ -1132,7 +1135,8 @@ void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, in
     }
 
     // Check x^3-direction
-    if (x3_off_grid and k != k_safe) {
+    if (x3_off_grid and k != k_safe)
+    {
       bool same_level_exists = level_alt == level;
       same_level_exists = same_level_exists and location_i_alt == location_i;
       same_level_exists = same_level_exists and location_j_alt == location_j;
@@ -1155,7 +1159,8 @@ void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, in
     }
 
     // Check x^3-direction across periodic boundary
-    if (x3_off_grid and simulation_coord == Coordinates::sks and k == -1 and location_k == 0) {
+    if (x3_off_grid and simulation_coord == Coordinates::sks and k == -1 and location_k == 0)
+    {
       bool same_level_exists = level_alt == level;
       same_level_exists = same_level_exists and location_i_alt == location_i;
       same_level_exists = same_level_exists and location_j_alt == location_j;
@@ -1174,7 +1179,8 @@ void RadiationIntegrator::FindNearbyInds(int b, int k, int j, int i, int k_c, in
         x3_off_grid = false;
     }
     if (x3_off_grid and simulation_coord == Coordinates::sks and k == n_k
-        and location_k == n_3_level(level) - 1) {
+        and location_k == n_3_level(level) - 1)
+    {
       bool same_level_exists = level_alt == level;
       same_level_exists = same_level_exists and location_i_alt == location_i;
       same_level_exists = same_level_exists and location_j_alt == location_j;

--- a/src/radiation_integrator/simulation_sampling.cpp
+++ b/src/radiation_integrator/simulation_sampling.cpp
@@ -72,6 +72,11 @@ void RadiationIntegrator::ObtainGridData()
   simulation_bounds = p_simulation_reader->simulation_bounds;
   sks_map = p_simulation_reader->sks_map;
 
+  // Copy thermodynamic variables
+  adiabatic_gamma = p_simulation_reader->adiabatic_gamma;
+  adiabatic_gamma_elec = p_simulation_reader->adiabatic_gamma_elec;
+  adiabatic_gamma_ion = p_simulation_reader->adiabatic_gamma_ion;
+
   // Calculate maximum refinement level and number of blocks in x^3-direction at each level
   if (simulation_format == SimulationFormat::athena and simulation_coord == Coordinates::sks
       and simulation_interp and simulation_block_interp)

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -398,7 +398,6 @@ void SimulationReader::GenerateSKSMap(double r_in, double r_out, int n1, int n2)
       sks_map(1, j, i) = x2;
     }
   }
-
   return;
 }
 
@@ -429,6 +428,7 @@ void SimulationReader::GetSKSCoordinates(double x1, double x2, double x3, double
     theta_J += 0.5 * Math::pi;
     *p_theta = theta_G + std::exp(mks_smooth * (std::log(rin) - x1)) * (theta_J - theta_G);
   }
+  return;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -477,4 +477,5 @@ void SimulationReader::SetJacobianFactors(double x1, double x2, double *p_dr_dx1
                         / ((1.0 + poly_alpha) * poly_xt)
                     - (1.0 - h) * Math::pi * std::cos(2.0 * Math::pi * x2));
   }
+  return;
 }

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -45,7 +45,9 @@ void SimulationReader::ConvertCoordinates()
 
     // Calculate grid bounds
     simulation_bounds.Allocate(6);
-    double r_val, theta_val, phival;
+    double r_val = 0.0;
+    double theta_val = 0.0;
+    double phi_val = 0.0;
     GetSKSCoordinates(x1f(0,0), 0.0, 0.0, &r_val, &theta_val, &phi_val);
     simulation_bounds(0) = r_val;
     simulation_bounds(2) = theta_val;
@@ -105,19 +107,19 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
       for (int i = 0; i < n1; i++)
       {
         // Extract coordinates
-        double r, th, x1, x2;
+        double r = x1v(0,i);
+        double th = x2v(0,j);
+        double x1, x2;
         if (simulation_coord == Coordinates::sks)
         {
-          r = x1v(0,i);
-          th = x2v(0,j);
           x1 = std::log(r);
           x2 = x2v_alt(j);
         }
         else if (simulation_coord == Coordinates::fmks)
         {
           double phi;
-          x1 = x1v(0,i);
-          x2 = x2v(0,j);
+          x1 = r;
+          x2 = th;
           GetSKSCoordinates(x1, x2, x3v(0,k), &r, &th, &phi);
         }
         else
@@ -363,7 +365,9 @@ void SimulationReader::GenerateSKSMap(double r_in, double r_out)
         double x2_b = 1.0;
         x2 = (x2_b + x2_a) / 2.0;
         double temp_r, temp_phi;
-        double theta_a, theta_b, theta_c;
+        double theta_a = 0.0;
+        double theta_b = Math::pi;
+        double theta_c = Math::pi / 2.0;
         GetSKSCoordinates(x1, x2_a, 0.0, &temp_r, &theta_a, &temp_phi);
         GetSKSCoordinates(x1, x2_b, 0.0, &temp_r, &theta_b, &temp_phi);
 
@@ -454,7 +458,7 @@ void SimulationReader::SetJacobianFactors(double x1, double x2, double *p_dr_dx1
     double var_h = Math::pi + (1.0 - metric_h) * Math::pi * std::cos(2.0 * Math::pi * x2);
     double var_i = -Math::pi + 2.0 * var_e;
     double var_j = 2.0 * metric_derived_poly_norm * metric_poly_alpha * var_c / var_d;
-    double var_k = -(1.0 - metric_h) * Math::pi * std::cos(2.0 * Math::pi * x2)
+    double var_k = -(1.0 - metric_h) * Math::pi * std::cos(2.0 * Math::pi * x2);
     *p_dth_dx2 = var_h + var_a * (var_i + var_j + var_k);
   }
 

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -8,8 +8,9 @@
 
 // Blacklight headers
 #include "simulation_reader.hpp"
-#include "../blacklight.hpp"      // Math
-#include "../utils/array.hpp"     // Array
+#include "../blacklight.hpp"        // Math
+#include "../utils/array.hpp"       // Array
+#include "../utils/exceptions.hpp"  // BlacklightException
 
 //--------------------------------------------------------------------------------------------------
 
@@ -17,10 +18,13 @@
 // Inputs: (none)
 // Outputs: (none)
 // Notes:
-//   Assumes x1f, x2f, x1v, and x2v are set in modified coordinates.
-//   Allocates and sets x2v_alt to save modified coordinates.
-//   Transforms x1f, x2f, x1v, and x2v.
-//   Operates in serial, given all arrays are 1D and likely to be small.
+//   If simulation coordinates are FMKS (MMKS):
+//     Populate sks_map but leave x[123][vf] unchanged, i.e., in native FMKS coordiantes.
+//   Otherwise:
+//     Assumes x1f, x2f, x1v, and x2v are set in modified coordinates.
+//     Allocates and sets x2v_alt to save modified coordinates for regular MKS.
+//     Transforms x1f, x2f, x1v, and x2v.
+//     Operates in serial, given all arrays are 1D and likely to be small.
 void SimulationReader::ConvertCoordinates()
 {
   // Extract parameters
@@ -28,23 +32,212 @@ void SimulationReader::ConvertCoordinates()
   int n1 = x1v.n1;
   int n2 = x2v.n1;
 
-  // Copy x^2 values
-  x2v_alt.Allocate(n2);
-  for (int j = 0; j < n2; j++)
-    x2v_alt(j) = x2v(0,j);
+  if (simulation_coord == Coordinates::fmks)
+  {
+    double r_in = std::exp(x1f(0, 0));
+    double r_out = std::exp(x1f(0, n1));
+    GenerateSKSMap(r_in, r_out, 512, 512);
+    
+    simulation_bounds.Allocate(6);
 
-  // Transform x^1 to r
-  for (int i = 0; i <= n1; i++)
-    x1f(0,i) = std::exp(x1f(0,i));
-  for (int i = 0; i < n1; i++)
-    x1v(0,i) = std::exp(x1v(0,i));
+    double rval, thetaval, phival;
+    GetSKSCoordinate(x1f(0, 0), 0.0, 0.0, rval, thetaval, phival);
+    simulation_bounds(0) = rval;
+    simulation_bounds(2) = thetaval;
+    simulation_bounds(4) = phival;
 
-  // Transform x^2 to theta
-  for (int j = 0; j <= n2; j++)
-    x2f(0,j) = Math::pi * x2f(0,j) + (1.0 - h) / 2.0 * std::sin(2.0 * Math::pi * x2f(0,j));
-  for (int j = 0; j < n2; j++)
-    x2v(0,j) = Math::pi * x2v(0,j) + (1.0 - h) / 2.0 * std::sin(2.0 * Math::pi * x2v(0,j));
+    GetSKSCoordinate(x1f(0, n1), 1.0, 2.0*Math::pi, rval, thetaval, phival);
+    simulation_bounds(1) = rval;
+    simulation_bounds(3) = thetaval;
+    simulation_bounds(5) = phival;
+
+    // TODO: remove
+    fprintf(stderr, "bounds: %g %g %g %g %g %g\n", simulation_bounds(0), simulation_bounds(1), simulation_bounds(2), simulation_bounds(3), simulation_bounds(4), simulation_bounds(5));
+  }
+  else
+  {
+    // Copy x^2 values
+    x2v_alt.Allocate(n2);
+    for (int j = 0; j < n2; j++)
+      x2v_alt(j) = x2v(0,j);
+    
+    // Transform x^1 to r
+    for (int i = 0; i <= n1; i++)
+      x1f(0,i) = std::exp(x1f(0,i));
+    for (int i = 0; i < n1; i++)
+      x1v(0,i) = std::exp(x1v(0,i));
+
+    // Transform x^2 to theta
+    for (int j = 0; j <= n2; j++)
+      x2f(0,j) = Math::pi * x2f(0,j) + (1.0 - h) / 2.0 * std::sin(2.0 * Math::pi * x2f(0,j));
+    for (int j = 0; j < n2; j++)
+      x2v(0,j) = Math::pi * x2v(0,j) + (1.0 - h) / 2.0 * std::sin(2.0 * Math::pi * x2v(0,j));
+  }
+
   return;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+// Function to return spatial SKS (r, theta, phi) coordinates given input coordiantes in
+// native coordinate system.
+// Inputs:
+//   x1, x2, x3: coordinate point in simulation coordinates
+// Outputs:
+//   r, theta, phi: spherical Kerr-Schild coordinates for (x1, x2, x3)
+void SimulationReader::GetSKSCoordinate(double x1, double x2, double x3, double &r, double &theta, double &phi)
+{
+  double h = metric_h;
+  double poly_xt = metric_poly_xt;
+  double poly_alpha = metric_poly_alpha;
+  double mks_smooth = metric_mks_smooth;
+  double rin = metric_rin;
+  double poly_norm = metric_derived_poly_norm;
+
+  if (simulation_coord == Coordinates::fmks) {
+    r = exp(x1);
+    phi = x3;
+    double y = 2.0 * x2 - 1.0;
+    double theta_G = Math::pi*x2 + ((1.0 - h) / 2.0) * std::sin(2.0 * Math::pi * x2);
+    double theta_J = poly_norm * y * (1.0 + std::pow(y / poly_xt, poly_alpha) / (poly_alpha + 1.0));
+    theta_J += 0.5 * Math::pi;
+    theta = theta_G + std::exp(mks_smooth * (std::log(rin) - x1)) * (theta_J - theta_G);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+
+// Function to generate the map between SKS (r, theta) coordinates and alternative
+// spherically based coordinate systems like FMKS. Currently written for FMKS.
+// Inputs: 
+//   r_in: radial SKS coordinate for "inner edge" of coordinate map
+//   r_out: radial SKS coordinate for "outer edge" of coordinate map
+//   n1: number of SKS grid points (in radial direction) to sample over
+//   n2: number of SKS grid points (in elevation/theta direction) to sample over
+// Outputs: (none)
+// Notes:
+//   Assumes all metric parameters have been loaded.
+//   Allocates and sets sks_map to save mapping.
+//   Operates in serial since it only needs to run once and is 2D.
+void SimulationReader::GenerateSKSMap(double r_in, double r_out, int n1, int n2)
+{
+  // TODO: these are not deallocated and will not work if the mesh coordinates change with time
+  sks_map.Allocate(2, n2, n1);
+
+  double dr = (r_out - r_in) / (n1 - 1);
+  double dtheta = Math::pi / (n2 - 1);
+
+  sks_map_rin = r_in;
+  sks_map_rout = r_out;
+  sks_map_dr = dr;
+  sks_map_dtheta = dtheta;
+
+  // TODO: this is a reasonable value, but maybe it should be set somewhere else
+  double TOLERANCE = 1.e-8;
+
+  for (int i = 0; i < n1; ++i)
+  {
+    double r = r_in + i * dr;
+    double x1 = log(r);
+    for (int j = 0; j < n2; ++j)
+    {
+      double theta = std::min(j * dtheta, Math::pi);
+      double x2 = 0.5;
+
+      if (theta > TOLERANCE && fabs(Math::pi - theta) > TOLERANCE)
+      {
+        // bisect down to correct value for x2
+        double x2a = 0.0;
+        double x2b = 1.0;
+        x2 = (x2b + x2a) / 2.0;
+
+        double tr, tphi;
+        double theta_a = 0.0;
+        double theta_b = Math::pi;
+        double theta_c = Math::pi/2.0;
+        GetSKSCoordinate(x1, x2a, 0.0, tr, theta_a, tphi);
+        GetSKSCoordinate(x1, x2b, 0.0, tr, theta_b, tphi);
+
+        for (int k = 0; k < 1000; ++k) {
+          GetSKSCoordinate(x1, x2, 0.0, tr, theta_c, tphi);
+          if ((theta_c - theta) * (theta_b - theta) < 0.0) {
+            theta_a = theta_c;
+            x2a = x2;
+          } else {
+            theta_b = theta_c;
+            x2b = x2;
+          }
+          x2 = (x2a + x2b) / 2.0;
+          if (fabs(theta - theta_c) < TOLERANCE) {
+            break;
+          }
+        }
+      } 
+      
+      else if (theta < TOLERANCE) 
+      {
+        x2 = 0.0;
+      } 
+      
+      else if (fabs(Math::pi - theta) < TOLERANCE) 
+      {
+        x2 = 1.0;
+      }
+
+      // set coordinates in mesh
+      sks_map(0, j, i) = x1;
+      sks_map(1, j, i) = x2;
+    }
+  }
+
+  return;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+// Function to set transformation factors from native (simulation) coordinates to spherical Kerr-Schild
+// Inputs:
+//   x1, x2 simulation coordinates for where to compute the transformation
+// Outputs:
+//   dr_dx1, dth_dx1, dth_dx2: Jacobian factors
+void SimulationReader::SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1, double &dth_dx2)
+{
+  double h = metric_h;
+  double poly_xt = metric_poly_xt;
+  double poly_alpha = metric_poly_alpha;
+  double mks_smooth = metric_mks_smooth;
+  double rin = metric_rin;
+  double poly_norm = metric_derived_poly_norm;
+
+  // regular MKS
+  dr_dx1 = std::exp(x1);
+  dth_dx1 = 0.0;
+  dth_dx2 = Math::pi + (1.0 - h) * Math::pi * std::cos(2.0 * Math::pi * x2);
+  
+  // FMKS
+  if (simulation_coord == Coordinates::fmks)
+  {
+    dth_dx1 = - std::exp(mks_smooth * (std::log(rin) - x1)) * mks_smooth
+            * (
+            Math::pi / 2.0 -
+            Math::pi * x2
+                + poly_norm * (2.0 * x2 - 1.0)
+                    * (1.0
+                        + (std::pow((-1.0 + 2.0*x2) / poly_xt, poly_alpha))
+                            / (1.0 + poly_alpha))
+                - 1.0 / 2.0 * (1.0 - h) * std::sin(2.0 * Math::pi * x2));
+    dth_dx2 = Math::pi + (1.0 - h) * Math::pi * std::cos(2.0 * Math::pi * x2)
+            + std::exp(mks_smooth * (std::log(rin) - x1))
+                * (-Math::pi
+                    + 2.0 * poly_norm
+                        * (1.0
+                            + std::pow((2.0*x2 - 1.0) / poly_xt, poly_alpha)
+                                / (poly_alpha + 1.0))
+                    + (2.0 * poly_alpha * poly_norm * (2.0*x2 - 1.0)
+                        * std::pow((2.0*x2 - 1.0) / poly_xt, poly_alpha - 1.0))
+                        / ((1.0 + poly_alpha) * poly_xt)
+                    - (1.0 - h) * Math::pi * std::cos(2.0 * Math::pi * x2));
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -62,7 +255,6 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
 {
   // Extract parameters
   double a = simulation_a;
-  double h = metric_h;
   int n1 = x1v.n1;
   int n2 = x2v.n1;
   int n3 = x3v.n1;
@@ -74,11 +266,27 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
       for (int i = 0; i < n1; i++)
       {
         // Extract coordinates
-        double r = x1v(0,i);
-        double th = x2v(0,j);
+        double r, th, x1, x2;
+        if (simulation_coord == Coordinates::sks)
+        {
+          r = x1v(0,i);
+          th = x2v(0,j);
+          x1 = std::log(r);
+          x2 = x2v_alt(j);
+        }
+        else if (simulation_coord == Coordinates::fmks)
+        {
+          double phi;
+          x1 = x1v(0,i);
+          x2 = x2v(0,j);
+          GetSKSCoordinate(x1, x2, x3v(0,k), r, th, phi);
+        }
+        else
+        {
+          throw BlacklightException("Attempting to translate primitives to CKS but could not process coordinates.");
+        }
         double sth = std::sin(th);
         double cth = std::cos(th);
-        double x2 = x2v_alt(j);
 
         // Extract primitives
         double uu1 = primitives(ind_uu1,0,k,j,i);
@@ -89,8 +297,8 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double bb3 = primitives(ind_bb3,0,k,j,i);
 
         // Calculate Jacobian of transformation
-        double dr_dx1 = r;
-        double dth_dx2 = Math::pi + (1.0 - h) * Math::pi * std::cos(2.0 * Math::pi * x2);
+        double dr_dx1, dth_dx1, dth_dx2;
+        SetJacobianFactors(x1, x2, dr_dx1, dth_dx1, dth_dx2);
 
         // Calculate standard metric
         double sigma = r * r + a * a * cth * cth;
@@ -111,22 +319,23 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double alpha = 1.0 / std::sqrt(-gtt);
 
         // Calculate modified metric
-        double g_01 = dr_dx1 * g_tr;
+        double g_01 = dr_dx1 * g_tr + dth_dx1 * g_tth;
         double g_02 = dth_dx2 * g_tth;
         double g_03 = g_tph;
-        double g_11 = dr_dx1 * dr_dx1 * g_rr;
-        double g_12 = dr_dx1 * dth_dx2 * g_rth;
-        double g_13 = dr_dx1 * g_rph;
-        double g_22 = dth_dx2 * dth_dx2 * g_thth;
+        double g_11 = dr_dx1*dr_dx1 * g_rr + 2.0 * dr_dx1 * dth_dx1 * g_rth + dth_dx1*dth_dx1 * g_thth;
+        double g_12 = dr_dx1 * dth_dx2 * g_rth + dth_dx1 * dth_dx2 * g_thth;
+        double g_13 = dr_dx1 * g_rph + dth_dx1 * g_thph;
+        double g_22 = dth_dx2*dth_dx2 * g_thth;
         double g_23 = dth_dx2 * g_thph;
         double g_33 = g_phph;
         double g00 = gtt;
         double g01 = gtr / dr_dx1;
-        double g02 = gtth / dth_dx2;
+        double g02 = g_tth / dth_dx2 - (dth_dx1 * g_tr) / (dr_dx1 * dth_dx2);
         double g03 = gtph;
         double alpha_mod = 1.0 / std::sqrt(-g00);
 
         // Transform velocity from modified normal frame to modified coordinate frame
+        // TODO check for missing terms .. does anything need g_00? 
         double uu0 = std::sqrt(1.0 + g_11 * uu1 * uu1 + 2.0 * g_12 * uu1 * uu2
             + 2.0 * g_13 * uu1 * uu3 + g_22 * uu2 * uu2 + 2.0 * g_23 * uu2 * uu3
             + g_33 * uu3 * uu3);
@@ -141,7 +350,7 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         // Transform velocity from modified coordinate frame to standard coordinate frame
         double ut = u0;
         double ur = dr_dx1 * u1;
-        double uth = dth_dx2 * u2;
+        double uth = dth_dx1 * u1 + dth_dx2 * u2;
         double uph = u3;
 
         // Transform velocity from standard coordinate frame to standard normal frame
@@ -158,7 +367,7 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         // Transform magnetic 4-vector from modified coordinate frame to standard coordinate frame
         double bt = b0;
         double br = dr_dx1 * b1;
-        double bth = dth_dx2 * b2;
+        double bth = dth_dx1 * b1 + dth_dx2 * b2;
         double bph = b3;
 
         // Calculate magnetic field in standard coordinate frame
@@ -173,6 +382,7 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         primitives(ind_bb1,0,k,j,i) = static_cast<float>(bbr);
         primitives(ind_bb2,0,k,j,i) = static_cast<float>(bbth);
         primitives(ind_bb3,0,k,j,i) = static_cast<float>(bbph);
+        
       }
   return;
 }
@@ -190,6 +400,9 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
 //   Assumes ind_u0, ind_uu1, ind_uu2, ind_uu3, ind_b0, ind_bb1, ind_bb2, and ind_bb3 are set.
 void SimulationReader::ConvertPrimitives4(Array<float> &primitives)
 {
+  // TODO check that we are in mks rather than fmks?
+  //      it seems unlikely to me that this would happen by accident but might be good to check.
+
   // Extract parameters
   double a = simulation_a;
   double h = metric_h;

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -36,7 +36,7 @@ void SimulationReader::ConvertCoordinates()
   {
     double r_in = std::exp(x1f(0, 0));
     double r_out = std::exp(x1f(0, n1));
-    GenerateSKSMap(r_in, r_out, 512, 512);
+    GenerateSKSMap(r_in, r_out, 2048, 2048);
     
     simulation_bounds.Allocate(6);
 
@@ -347,6 +347,18 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double u_2 = g_02 * u0 + g_12 * u1 + g_22 * u2 + g_23 * u3;
         double u_3 = g_03 * u0 + g_13 * u1 + g_23 * u2 + g_33 * u3;
 
+        // TODO remove
+        /*
+        fprintf(stderr, "gcov %g %g %g %g %g %g %g %g %g\n", g_01, g_02, g_03, g_11, g_12, g_13, g_22, g_23, g_33);
+        fprintf(stderr, "gcon %g %g %g %g\n", g00, g01, g02, g03);
+
+        fprintf(stderr, "%d %d %d -> %g %g (%g %g)\n", i, j, k, r, th, x1, x2);
+        fprintf(stderr, "%g %g %g\n", uu1, uu2, uu3);
+        // prims are what we expect
+        fprintf(stderr, "fmks %g %g %g %g %g %g %g\n", u0, u1, u2, u3, u_1, u_2, u_3);
+        // ucon_fmks is what we expect
+         */
+
         // Transform velocity from modified coordinate frame to standard coordinate frame
         double ut = u0;
         double ur = dr_dx1 * u1;
@@ -357,6 +369,12 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double uur = ur + alpha * alpha * gtr * ut;
         double uuth = uth + alpha * alpha * gtth * ut;
         double uuph = uph + alpha * alpha * gtph * ut;
+
+        // TODO remove
+        //fprintf(stderr, "ucon_ks %g %g %g %g\n", ut, ur, uth, uph);
+        //fprintf(stderr, "uprim_ks %g %g %g\n", uur, uuth, uuph);
+        // so this should be good ...
+        //std::exit(4);
 
         // Calculate magnetic 4-vector in modified coordinate frame
         double b0 = u_1 * bb1 + u_2 * bb2 + u_3 * bb3;
@@ -375,6 +393,15 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double bbth = bth * ut - bt * uth;
         double bbph = bph * ut - bt * uph;
 
+        // TODO remove
+        /*
+        fprintf(stderr, "fmks Bi bcon %g %g %g %g %g %g %g\n", bb1, bb2, bb3, b0, b1, b2, b3);
+        fprintf(stderr, "bcon_ks %g %g %g %g\n", bt, br, bth, bph);
+        fprintf(stderr, "bprim_ks %g %g %g\n", bbr, bbth, bbph);
+        // these values also agree
+        std::exit(4);
+         */
+        
         // Save results
         primitives(ind_uu1,0,k,j,i) = static_cast<float>(uur);
         primitives(ind_uu2,0,k,j,i) = static_cast<float>(uuth);

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -37,7 +37,7 @@ void SimulationReader::ConvertCoordinates()
     double r_in = std::exp(x1f(0, 0));
     double r_out = std::exp(x1f(0, n1));
     GenerateSKSMap(r_in, r_out, 2048, 2048);
-    
+
     simulation_bounds.Allocate(6);
 
     double rval, thetaval, phival;
@@ -60,7 +60,7 @@ void SimulationReader::ConvertCoordinates()
     x2v_alt.Allocate(n2);
     for (int j = 0; j < n2; j++)
       x2v_alt(j) = x2v(0,j);
-    
+
     // Transform x^1 to r
     for (int i = 0; i <= n1; i++)
       x1f(0,i) = std::exp(x1f(0,i));
@@ -109,7 +109,7 @@ void SimulationReader::GetSKSCoordinate(double x1, double x2, double x3, double 
 
 // Function to generate the map between SKS (r, theta) coordinates and alternative
 // spherically based coordinate systems like FMKS. Currently written for FMKS.
-// Inputs: 
+// Inputs:
 //   r_in: radial SKS coordinate for "inner edge" of coordinate map
 //   r_out: radial SKS coordinate for "outer edge" of coordinate map
 //   n1: number of SKS grid points (in radial direction) to sample over
@@ -172,14 +172,14 @@ void SimulationReader::GenerateSKSMap(double r_in, double r_out, int n1, int n2)
             break;
           }
         }
-      } 
-      
-      else if (theta < TOLERANCE) 
+      }
+
+      else if (theta < TOLERANCE)
       {
         x2 = 0.0;
-      } 
-      
-      else if (fabs(Math::pi - theta) < TOLERANCE) 
+      }
+
+      else if (fabs(Math::pi - theta) < TOLERANCE)
       {
         x2 = 1.0;
       }
@@ -213,7 +213,7 @@ void SimulationReader::SetJacobianFactors(double x1, double x2, double &dr_dx1, 
   dr_dx1 = std::exp(x1);
   dth_dx1 = 0.0;
   dth_dx2 = Math::pi + (1.0 - h) * Math::pi * std::cos(2.0 * Math::pi * x2);
-  
+
   // FMKS
   if (simulation_coord == Coordinates::fmks)
   {
@@ -335,7 +335,7 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double alpha_mod = 1.0 / std::sqrt(-g00);
 
         // Transform velocity from modified normal frame to modified coordinate frame
-        // TODO check for missing terms .. does anything need g_00? 
+        // TODO check for missing terms .. does anything need g_00?
         double uu0 = std::sqrt(1.0 + g_11 * uu1 * uu1 + 2.0 * g_12 * uu1 * uu2
             + 2.0 * g_13 * uu1 * uu3 + g_22 * uu2 * uu2 + 2.0 * g_23 * uu2 * uu3
             + g_33 * uu3 * uu3);
@@ -401,7 +401,7 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         // these values also agree
         std::exit(4);
          */
-        
+
         // Save results
         primitives(ind_uu1,0,k,j,i) = static_cast<float>(uur);
         primitives(ind_uu2,0,k,j,i) = static_cast<float>(uuth);
@@ -409,7 +409,7 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         primitives(ind_bb1,0,k,j,i) = static_cast<float>(bbr);
         primitives(ind_bb2,0,k,j,i) = static_cast<float>(bbth);
         primitives(ind_bb3,0,k,j,i) = static_cast<float>(bbph);
-        
+
       }
   return;
 }

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -353,7 +353,7 @@ void SimulationReader::GenerateSKSMap(double r_in, double r_out, int n1, int n2)
       double theta = std::min(j * dtheta, Math::pi);
       double x2 = 0.5;
 
-      if (theta > TOLERANCE && fabs(Math::pi - theta) > TOLERANCE)
+      if (theta > TOLERANCE and fabs(Math::pi - theta) > TOLERANCE)
       {
         // bisect down to correct value for x2
         double x2a = 0.0;

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -329,7 +329,6 @@ void SimulationReader::ConvertPrimitives4(Array<float> &primitives)
 //   Operates in serial since it only needs to run once and is 2D.
 void SimulationReader::GenerateSKSMap(double r_in, double r_out)
 {
-  // TODO: these are not deallocated and will not work if the mesh coordinates change with time
   // Allocate map
   sks_map.Allocate(2, sks_map_n2, sks_map_n1);
 

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -367,31 +367,30 @@ void SimulationReader::GenerateSKSMap(double r_in, double r_out, int n1, int n2)
         GetSKSCoordinates(x1, x2a, 0.0, &tr, &theta_a, &tphi);
         GetSKSCoordinates(x1, x2b, 0.0, &tr, &theta_b, &tphi);
 
-        for (int k = 0; k < 1000; ++k) {
+        for (int k = 0; k < 1000; ++k)
+        {
           GetSKSCoordinates(x1, x2, 0.0, &tr, &theta_c, &tphi);
-          if ((theta_c - theta) * (theta_b - theta) < 0.0) {
+          if ((theta_c - theta) * (theta_b - theta) < 0.0)
+          {
             theta_a = theta_c;
             x2a = x2;
-          } else {
+          }
+          else
+          {
             theta_b = theta_c;
             x2b = x2;
           }
           x2 = (x2a + x2b) / 2.0;
-          if (fabs(theta - theta_c) < TOLERANCE) {
+          if (fabs(theta - theta_c) < TOLERANCE)
             break;
-          }
         }
       }
 
       else if (theta < TOLERANCE)
-      {
         x2 = 0.0;
-      }
 
       else if (fabs(Math::pi - theta) < TOLERANCE)
-      {
         x2 = 1.0;
-      }
 
       // set coordinates in mesh
       sks_map(0, j, i) = x1;
@@ -419,7 +418,8 @@ void SimulationReader::GetSKSCoordinates(double x1, double x2, double x3, double
   double rin = metric_rin;
   double poly_norm = metric_derived_poly_norm;
 
-  if (simulation_coord == Coordinates::fmks) {
+  if (simulation_coord == Coordinates::fmks)
+  {
     *p_r = exp(x1);
     *p_phi = x3;
     double y = 2.0 * x2 - 1.0;

--- a/src/simulation_reader/simulation_geometry.cpp
+++ b/src/simulation_reader/simulation_geometry.cpp
@@ -50,9 +50,6 @@ void SimulationReader::ConvertCoordinates()
     simulation_bounds(1) = rval;
     simulation_bounds(3) = thetaval;
     simulation_bounds(5) = phival;
-
-    // TODO: remove
-    fprintf(stderr, "bounds: %g %g %g %g %g %g\n", simulation_bounds(0), simulation_bounds(1), simulation_bounds(2), simulation_bounds(3), simulation_bounds(4), simulation_bounds(5));
   }
   else
   {
@@ -85,7 +82,8 @@ void SimulationReader::ConvertCoordinates()
 //   x1, x2, x3: coordinate point in simulation coordinates
 // Outputs:
 //   r, theta, phi: spherical Kerr-Schild coordinates for (x1, x2, x3)
-void SimulationReader::GetSKSCoordinate(double x1, double x2, double x3, double &r, double &theta, double &phi)
+void SimulationReader::GetSKSCoordinate(double x1, double x2, double x3, double &r, double &theta,
+    double &phi)
 {
   double h = metric_h;
   double poly_xt = metric_poly_xt;
@@ -195,12 +193,13 @@ void SimulationReader::GenerateSKSMap(double r_in, double r_out, int n1, int n2)
 
 //--------------------------------------------------------------------------------------------------
 
-// Function to set transformation factors from native (simulation) coordinates to spherical Kerr-Schild
+// Function to set transformation factors from native (simulation) coordinates to SKS
 // Inputs:
 //   x1, x2 simulation coordinates for where to compute the transformation
 // Outputs:
 //   dr_dx1, dth_dx1, dth_dx2: Jacobian factors
-void SimulationReader::SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1, double &dth_dx2)
+void SimulationReader::SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1,
+    double &dth_dx2)
 {
   double h = metric_h;
   double poly_xt = metric_poly_xt;
@@ -283,7 +282,8 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         }
         else
         {
-          throw BlacklightException("Attempting to translate primitives to CKS but could not process coordinates.");
+          throw BlacklightException(
+              "Attempting to translate primitives to CKS but could not process coordinates.");
         }
         double sth = std::sin(th);
         double cth = std::cos(th);
@@ -322,7 +322,8 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double g_01 = dr_dx1 * g_tr + dth_dx1 * g_tth;
         double g_02 = dth_dx2 * g_tth;
         double g_03 = g_tph;
-        double g_11 = dr_dx1*dr_dx1 * g_rr + 2.0 * dr_dx1 * dth_dx1 * g_rth + dth_dx1*dth_dx1 * g_thth;
+        double g_11 =
+            dr_dx1*dr_dx1 * g_rr + 2.0 * dr_dx1 * dth_dx1 * g_rth + dth_dx1*dth_dx1 * g_thth;
         double g_12 = dr_dx1 * dth_dx2 * g_rth + dth_dx1 * dth_dx2 * g_thth;
         double g_13 = dr_dx1 * g_rph + dth_dx1 * g_thph;
         double g_22 = dth_dx2*dth_dx2 * g_thth;
@@ -347,18 +348,6 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double u_2 = g_02 * u0 + g_12 * u1 + g_22 * u2 + g_23 * u3;
         double u_3 = g_03 * u0 + g_13 * u1 + g_23 * u2 + g_33 * u3;
 
-        // TODO remove
-        /*
-        fprintf(stderr, "gcov %g %g %g %g %g %g %g %g %g\n", g_01, g_02, g_03, g_11, g_12, g_13, g_22, g_23, g_33);
-        fprintf(stderr, "gcon %g %g %g %g\n", g00, g01, g02, g03);
-
-        fprintf(stderr, "%d %d %d -> %g %g (%g %g)\n", i, j, k, r, th, x1, x2);
-        fprintf(stderr, "%g %g %g\n", uu1, uu2, uu3);
-        // prims are what we expect
-        fprintf(stderr, "fmks %g %g %g %g %g %g %g\n", u0, u1, u2, u3, u_1, u_2, u_3);
-        // ucon_fmks is what we expect
-         */
-
         // Transform velocity from modified coordinate frame to standard coordinate frame
         double ut = u0;
         double ur = dr_dx1 * u1;
@@ -369,12 +358,6 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double uur = ur + alpha * alpha * gtr * ut;
         double uuth = uth + alpha * alpha * gtth * ut;
         double uuph = uph + alpha * alpha * gtph * ut;
-
-        // TODO remove
-        //fprintf(stderr, "ucon_ks %g %g %g %g\n", ut, ur, uth, uph);
-        //fprintf(stderr, "uprim_ks %g %g %g\n", uur, uuth, uuph);
-        // so this should be good ...
-        //std::exit(4);
 
         // Calculate magnetic 4-vector in modified coordinate frame
         double b0 = u_1 * bb1 + u_2 * bb2 + u_3 * bb3;
@@ -392,15 +375,6 @@ void SimulationReader::ConvertPrimitives3(Array<float> &primitives)
         double bbr = br * ut - bt * ur;
         double bbth = bth * ut - bt * uth;
         double bbph = bph * ut - bt * uph;
-
-        // TODO remove
-        /*
-        fprintf(stderr, "fmks Bi bcon %g %g %g %g %g %g %g\n", bb1, bb2, bb3, b0, b1, b2, b3);
-        fprintf(stderr, "bcon_ks %g %g %g %g\n", bt, br, bth, bph);
-        fprintf(stderr, "bprim_ks %g %g %g\n", bbr, bbth, bbph);
-        // these values also agree
-        std::exit(4);
-         */
 
         // Save results
         primitives(ind_uu1,0,k,j,i) = static_cast<float>(uur);

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -716,9 +716,7 @@ double SimulationReader::Read(int snapshot)
     // Check coordinates
     if (first_time)
     {
-      // TODO: I wantonly added fmks in here and below. Check for correctness?
-      if ((simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
-          and x2f.n2 == 1)
+      if (simulation_coord == Coordinates::sks and x2f.n2 == 1)
       {
         bool error_low = std::abs(x2f(0,0)) > (x2f(0,1) - x2f(0,0)) * angular_domain_tolerance;
         bool error_high = std::abs(x2f(0,x2f.n1-1) - Math::pi)
@@ -780,7 +778,6 @@ double SimulationReader::Read(int snapshot)
     {
       if (first_time)
       {
-        // TODO support num_variables and Thetae from electron thermodynamics
         VerifyVariablesHarm();
         int n5 = num_variables(0);
         int n4 = levels.n1;
@@ -1301,8 +1298,6 @@ void SimulationReader::VerifyVariablesHarm()
 {
   // Read number of primitives
   ReadHDF5IntArray("header/n_prim", num_variables);
-
-  // TODO make sure this is working correctly
 
   // Read names of primitives
   ReadHDF5StringArray("header/prim_names", num_variable_names == 0, &variable_names,

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -1363,7 +1363,7 @@ void SimulationReader::VerifyVariablesHarm()
     ReadHDF5DoubleArray("header/gam", gamma);
     if (not gamma_set)
       plasma_gamma = gamma(0);
-    else if (plasma_gamma != temp_val)
+    else if (plasma_gamma != gamma(0))
     {
       std::ostringstream message;
       message << "Given total adiabatic index of " << plasma_gamma;
@@ -1383,7 +1383,7 @@ void SimulationReader::VerifyVariablesHarm()
       ReadHDF5DoubleArray("header/gam_p", gamma);
       if (not gamma_i_set)
         plasma_gamma_i = gamma(0);
-      else if (plasma_gamma_i != temp_val)
+      else if (plasma_gamma_i != gamma(0))
       {
         std::ostringstream message;
         message << "Given ion adiabatic index of " << plasma_gamma_i;
@@ -1401,7 +1401,7 @@ void SimulationReader::VerifyVariablesHarm()
       ReadHDF5DoubleArray("header/gam_e", gamma);
       if (not gamma_e_set)
         plasma_gamma_e = gamma(0);
-      else if (plasma_gamma_e != temp_val)
+      else if (plasma_gamma_e != gamma(0))
       {
         std::ostringstream message;
         message << "Given electron adiabatic index of " << plasma_gamma_e;

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -310,7 +310,7 @@ double SimulationReader::Read(int snapshot)
       ReadHDF5StringArray("header/metric", true, &p_temp_metric, &temp_count);
       metric = *p_temp_metric;
       delete[] p_temp_metric;
-      if (simulation_coord == Coordinates::sks || simulation_coord == Coordinates::fmks)
+      if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
       {
         std::string metric_lower = metric;
         std::transform(metric_lower.begin(), metric_lower.end(), metric_lower.begin(),
@@ -647,7 +647,8 @@ double SimulationReader::Read(int snapshot)
     if (first_time)
     {
       // TODO: I wantonly added fmks in here and below. Check for correctness?
-      if ((simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks) and x2f.n2 == 1)
+      if ((simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
+          and x2f.n2 == 1)
       {
         bool error_low = std::abs(x2f(0,0)) > (x2f(0,1) - x2f(0,0)) * angular_domain_tolerance;
         bool error_high = std::abs(x2f(0,x2f.n1-1) - Math::pi)
@@ -664,7 +665,8 @@ double SimulationReader::Read(int snapshot)
           x2f(0,x2f.n1-1) = Math::pi;
         }
       }
-      if ((simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks) and x3f.n2 == 1)
+      if ((simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
+          and x3f.n2 == 1)
       {
         bool error_low = std::abs(x3f(0,0)) > (x3f(0,1) - x3f(0,0)) * angular_domain_tolerance;
         bool error_high = std::abs(x3f(0,x3f.n1-1) - 2.0 * Math::pi)

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -314,8 +314,8 @@ double SimulationReader::Read(int snapshot)
       if (simulation_coord == Coordinates::sks or simulation_coord == Coordinates::fmks)
       {
         std::string metric_lower = metric;
-        for (int c = 0; c < metric_lower.size; c++)
-          metric_lower[c] = std::tolower(metric_lower[c]);
+        for (unsigned int c = 0; c < metric_lower.size(); c++)
+          metric_lower[c] = static_cast<char>(std::tolower(metric_lower[c]));
         if (metric != "MKS" and metric != "MMKS" and metric != "FMKS")
         {
           std::ostringstream message;
@@ -609,7 +609,7 @@ double SimulationReader::Read(int snapshot)
         data_stream >> dx1 >> dx2 >> dx3;
         x1f.Allocate(1, num_cells_1 + 1);
         x1v.Allocate(1, num_cells_1);
-        x1f(0,0) = x_start(0);
+        x1f(0,0) = x1_start;
         for (int i = 0; i < num_cells_1; i++)
         {
           x1f(0,i+1) = x1_start + (i + 1) * dx1;
@@ -617,7 +617,7 @@ double SimulationReader::Read(int snapshot)
         }
         x2f.Allocate(1, num_cells_2 + 1);
         x2v.Allocate(1, num_cells_2);
-        x2f(0,0) = x_start(0);
+        x2f(0,0) = x2_start;
         for (int j = 0; j < num_cells_2; j++)
         {
           x2f(0,j+1) = x2_start + (j + 1) * dx2;
@@ -625,7 +625,7 @@ double SimulationReader::Read(int snapshot)
         }
         x3f.Allocate(1, num_cells_3 + 1);
         x3v.Allocate(1, num_cells_3);
-        x3f(0,0) = x_start(0);
+        x3f(0,0) = x3_start;
         for (int k = 0; k < num_cells_3; k++)
         {
           x3f(0,k+1) = x3_start + (k + 1) * dx3;

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -338,8 +338,10 @@ double SimulationReader::Read(int snapshot)
         if (metric == "MMKS" or metric == "FMKS") {
           Array<double> poly_xt_temp, poly_alpha_temp, mks_smooth_temp, rin_temp;
           ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_xt").c_str(), poly_xt_temp);
-          ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_alpha").c_str(), poly_alpha_temp);
-          ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/mks_smooth").c_str(), mks_smooth_temp);
+          ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_alpha").c_str(),
+              poly_alpha_temp);
+          ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/mks_smooth").c_str(),
+              mks_smooth_temp);
           try
           {
             ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/r_in").c_str(), rin_temp);
@@ -351,14 +353,16 @@ double SimulationReader::Read(int snapshot)
               ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/Rin").c_str(), rin_temp);
             }
             catch (...) {
-              throw BlacklightException("Unable to identify r_in parameter for iharm3d-format file.");
+              throw BlacklightException(
+                  "Unable to identify r_in parameter for iharm3d-format file.");
             }
           }
           metric_rin = rin_temp(0);
           metric_poly_xt = poly_xt_temp(0);
           metric_poly_alpha = poly_alpha_temp(0);
           metric_mks_smooth = mks_smooth_temp(0);
-          metric_derived_poly_norm = 1.0 / (1.0 + 1.0/(metric_poly_alpha+1.0)/std::pow(metric_poly_xt, metric_poly_alpha));
+          metric_derived_poly_norm = 1.0 / (1.0
+              + 1.0 / (metric_poly_alpha + 1.0) / std::pow(metric_poly_xt, metric_poly_alpha));
           metric_derived_poly_norm *= 0.5 * Math::pi;
           //native_x1in = std::log(metric_rin);
           //native_deltax1 =

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -340,7 +340,7 @@ double SimulationReader::Read(int snapshot)
           ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_xt").c_str(), poly_xt_temp);
           ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_alpha").c_str(), poly_alpha_temp);
           ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/mks_smooth").c_str(), mks_smooth_temp);
-          try 
+          try
           {
             ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/r_in").c_str(), rin_temp);
           }
@@ -361,7 +361,7 @@ double SimulationReader::Read(int snapshot)
           metric_derived_poly_norm = 1.0 / (1.0 + 1.0/(metric_poly_alpha+1.0)/std::pow(metric_poly_xt, metric_poly_alpha));
           metric_derived_poly_norm *= 0.5 * Math::pi;
           //native_x1in = std::log(metric_rin);
-          //native_deltax1 = 
+          //native_deltax1 =
           //native_deltax2 = 1.0 / n2;
         }
       }
@@ -558,7 +558,7 @@ double SimulationReader::Read(int snapshot)
       }
       else if (simulation_format == SimulationFormat::iharm3d)
       {
-        // TODO check that this makes sense. 
+        // TODO check that this makes sense.
         Array<int> num_cells;
         Array<double> x_start, dx;
         ReadHDF5IntArray("header/n1", num_cells);

--- a/src/simulation_reader/simulation_reader.cpp
+++ b/src/simulation_reader/simulation_reader.cpp
@@ -335,7 +335,8 @@ double SimulationReader::Read(int snapshot)
           BlacklightWarning(message.str().c_str());
         }
         metric_h = h_temp(0);
-        if (metric == "MMKS" or metric == "FMKS") {
+        if (metric == "MMKS" or metric == "FMKS")
+        {
           Array<double> poly_xt_temp, poly_alpha_temp, mks_smooth_temp, rin_temp;
           ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_xt").c_str(), poly_xt_temp);
           ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/poly_alpha").c_str(),
@@ -352,7 +353,8 @@ double SimulationReader::Read(int snapshot)
             {
               ReadHDF5DoubleArray(("header/geom/" + metric_lower + "/Rin").c_str(), rin_temp);
             }
-            catch (...) {
+            catch (...)
+            {
               throw BlacklightException(
                   "Unable to identify r_in parameter for iharm3d-format file.");
             }

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -125,11 +125,11 @@ struct SimulationReader
 
   // Internal functions - simulation_geometry.cpp
   void ConvertCoordinates();
-  void GenerateSKSMap(double r_in, double r_out, int n1, int n2);
-  void GetSKSCoordinate(double x1, double x2, double x3, double &r, double &theta, double &phi);
-  void SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1, double &dth_dx2);
   void ConvertPrimitives3(Array<float> &primitives);
   void ConvertPrimitives4(Array<float> &primitives);
+  void GenerateSKSMap(double r_in, double r_out, int n1, int n2);
+  void GetSKSCoordinates(double x1, double x2, double x3, double &r, double &theta, double &phi);
+  void SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1, double &dth_dx2);
 
   // Internal functions - hdf5_format_structure.cpp
   void ReadHDF5Superblock();

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -77,7 +77,8 @@ struct SimulationReader
   double athenak_time;
   double *athenak_cell_data_double;
   std::string metric;
-  double metric_a, metric_h;
+  double metric_a, metric_h, metric_poly_xt, metric_poly_alpha, metric_mks_smooth, metric_rin;
+  double metric_derived_poly_norm;
   std::ifstream::pos_type cell_data_address;
   std::string *dataset_names;
   int num_dataset_names = 0;
@@ -94,6 +95,11 @@ struct SimulationReader
   int latest_file_number;
   const double extrapolation_tolerance = 1.0;
   const double angular_domain_tolerance = 0.1;
+
+  // Coordinate interpolation data
+  double sks_map_rin, sks_map_rout, sks_map_dr, sks_map_dtheta;
+  Array<double> simulation_bounds;
+  Array<double> sks_map;
 
   // Data
   int n_3_root;
@@ -119,6 +125,9 @@ struct SimulationReader
 
   // Internal functions - simulation_geometry.cpp
   void ConvertCoordinates();
+  void GenerateSKSMap(double r_in, double r_out, int n1, int n2);
+  void GetSKSCoordinate(double x1, double x2, double x3, double &r, double &theta, double &phi);
+  void SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1, double &dth_dx2);
   void ConvertPrimitives3(Array<float> &primitives);
   void ConvertPrimitives4(Array<float> &primitives);
 

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -128,8 +128,10 @@ struct SimulationReader
   void ConvertPrimitives3(Array<float> &primitives);
   void ConvertPrimitives4(Array<float> &primitives);
   void GenerateSKSMap(double r_in, double r_out, int n1, int n2);
-  void GetSKSCoordinates(double x1, double x2, double x3, double &r, double &theta, double &phi);
-  void SetJacobianFactors(double x1, double x2, double &dr_dx1, double &dth_dx1, double &dth_dx2);
+  void GetSKSCoordinates(double x1, double x2, double x3, double *p_r, double *p_theta,
+      double *p_phi);
+  void SetJacobianFactors(double x1, double x2, double *p_dr_dx1, double *p_dth_dx1,
+      double *p_dth_dx2);
 
   // Internal functions - hdf5_format_structure.cpp
   void ReadHDF5Superblock();

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -131,7 +131,7 @@ struct SimulationReader
   void ConvertCoordinates();
   void ConvertPrimitives3(Array<float> &primitives);
   void ConvertPrimitives4(Array<float> &primitives);
-  void GenerateSKSMap(double r_in, double r_out, int n1, int n2);
+  void GenerateSKSMap(double r_in, double r_out);
   void GetSKSCoordinates(double x1, double x2, double x3, double *p_r, double *p_theta,
       double *p_phi);
   void SetJacobianFactors(double x1, double x2, double *p_dr_dx1, double *p_dth_dx1,

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -77,8 +77,8 @@ struct SimulationReader
   double athenak_time;
   double *athenak_cell_data_double;
   std::string metric;
-  double metric_a, metric_h, metric_poly_xt, metric_poly_alpha, metric_mks_smooth, metric_rin;
-  double metric_derived_poly_norm;
+  double metric_a, metric_h, metric_r_in;
+  double metric_poly_xt, metric_poly_alpha, metric_mks_smooth, metric_derived_poly_norm;
   std::ifstream::pos_type cell_data_address;
   std::string *dataset_names;
   int num_dataset_names = 0;
@@ -97,9 +97,13 @@ struct SimulationReader
   const double angular_domain_tolerance = 0.1;
 
   // Coordinate interpolation data
-  double sks_map_rin, sks_map_rout, sks_map_dr, sks_map_dtheta;
+  double sks_map_r_in, sks_map_r_out, sks_map_dr, sks_map_dtheta;
   Array<double> simulation_bounds;
   Array<double> sks_map;
+  const int sks_map_n1 = 2048;
+  const int sks_map_n2 = 2048;
+  const int sks_map_max_iter = 1000;
+  const double sks_map_tol = 1.0e-8;
 
   // Data
   int n_3_root;

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -90,11 +90,12 @@ struct SimulationReader
   int ind_rho, ind_pgas, ind_kappa;
   int ind_u0, ind_uu1, ind_uu2, ind_uu3;
   int ind_b0, ind_bb1, ind_bb2, ind_bb3;
-  double adiabatic_gamma;
   int num_arrays;
   int latest_file_number;
   const double extrapolation_tolerance = 1.0;
   const double angular_domain_tolerance = 0.1;
+  bool adiabatic_gamma_elec_set, adiabatic_gamma_ion_set;
+  double adiabatic_gamma, adiabatic_gamma_elec, adiabatic_gamma_ion;
 
   // Coordinate interpolation data
   double sks_map_r_in, sks_map_r_out, sks_map_dr, sks_map_dtheta;

--- a/src/simulation_reader/simulation_reader.hpp
+++ b/src/simulation_reader/simulation_reader.hpp
@@ -51,6 +51,10 @@ struct SimulationReader
   // Input data - plasma parameters
   double plasma_mu;
   PlasmaModel plasma_model;
+  bool plasma_use_p;
+  double plasma_gamma;
+  double plasma_gamma_i;
+  double plasma_gamma_e;
 
   // Flags for tracking function calls
   bool first_time = true;
@@ -94,8 +98,9 @@ struct SimulationReader
   int latest_file_number;
   const double extrapolation_tolerance = 1.0;
   const double angular_domain_tolerance = 0.1;
-  bool adiabatic_gamma_elec_set, adiabatic_gamma_ion_set;
-  double adiabatic_gamma, adiabatic_gamma_elec, adiabatic_gamma_ion;
+  bool gamma_set = false;
+  bool gamma_i_set = false;
+  bool gamma_e_set = false;
 
   // Coordinate interpolation data
   double sks_map_r_in, sks_map_r_out, sks_map_dr, sks_map_dtheta;


### PR DESCRIPTION
The commits in this pull request implement support for FMKS coordinates. Since there is not a clear way to go from Kerr-Schild coordinates to FMKS coordinates without performing root finding, the code implements a so-called "sks-map" feature, which provides a general framework for identifying "which [native/simulation] coordinates correspond to a given Spherical Kerr Schild point". The ```sks-map``` variable is a set of 2 two-dimensional arrays that provide the native ```x1``` and ```x2``` coordinates for KS coordinate points regularly spaced in ```r``` and ```theta```. 

There's a lot in this PR, and I would not be surprised if some of the design choices are objectionable.

Right now, the code also isn't fully tested. I will update the text of this PR as I go through the tests and other validation.

### Checklist
- [x] Check that ```sks-map``` implementation gives expected values.
- [x] Check that code-to-cgs conversions give expected values.
- [x] Check that SKS vector components give expected values.
- [ ] Add info to function docstrings for when to/not to treat ```Coordinates::fmks``` as ```Coordiantes::sks```
- [ ] Troubleshoot spurious hot pixels.
- [ ] Troubleshoot large values in "final step".

### Other notes
- ```blacklight``` saves the primitives (including for fluid velocity and magnetic field), interpolates them in regular sks, and then constructs scalars. This procedure will yield different values for things like ```bsq``` (and therefore ```sigma```) compared to ```ipole```, which saves the scalars in fmks and interpolates there. The differences are largest where fmks and sks differ substantially (e.g., near poles) and where the four-vectors vary rapidly. It doesn't seem to be that much of a problem (see images below), but it's good to keep in mind.
- ```blacklight``` uses a different formula for computing ```Theta_e``` given fluid density and total internal energy. The local difference turns out to be a factor of ```2.0 * (2.0 + R) / 3.0 / (1.0 + R)``` for a given ```R = T_i/T_e``` assuming ```game = 4.0/3.0``` and ```gamp = 5.0/3.0```. To produce the comparison, I modified ```ipole```'s method for computing ```Theta_e``` to match ```blacklight```'s, but that change will not be persisted to the public version of ```ipole```.